### PR TITLE
fix item search

### DIFF
--- a/src/VariableSizeGrid.js
+++ b/src/VariableSizeGrid.js
@@ -144,11 +144,12 @@ const findNearestItem = (
     // If we haven't yet measured this high, fallback to an exponential search with an inner binary search.
     // The exponential search avoids pre-computing sizes for the full set of items as a binary search would.
     // The overall complexity for this approach is O(log n).
+    const index = lastMeasuredIndex > 0 ? lastMeasuredIndex : 0;
     return findNearestItemExponentialSearch(
       itemType,
       props,
       instanceProps,
-      lastMeasuredIndex,
+      index,
       offset
     );
   }

--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -78,10 +78,11 @@ const findNearestItem = (
     // If we haven't yet measured this high, fallback to an exponential search with an inner binary search.
     // The exponential search avoids pre-computing sizes for the full set of items as a binary search would.
     // The overall complexity for this approach is O(log n).
+    const index = lastMeasuredIndex > 0 ? lastMeasuredIndex : 0;
     return findNearestItemExponentialSearch(
       props,
       instanceProps,
-      lastMeasuredIndex,
+      index,
       offset
     );
   }


### PR DESCRIPTION
the `lastMeasuredIndex` could be `-1` after `resetAfterIndex`, then `findNearestItemExponentialSearch` would crash because `getItemMetadata(itemType, props, index, instanceProps)` is undefined