### PR TITLE
Keep dependencies as external

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "name": "react-window",
   "version": "1.0.1",
-  "description":
-    "React components for efficiently rendering large, scrollable lists and tabular data",
-  "author":
-    "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
+  "description": "React components for efficiently rendering large, scrollable lists and tabular data",
+  "author": "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
   "contributors": [
     "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)"
   ],
@@ -36,7 +34,9 @@
   ],
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "precommit": "lint-staged",
     "prettier": "prettier --write '**/*.{js,json,css}'",
@@ -52,7 +52,10 @@
     "website:run": "cd website && yarn start"
   },
   "lint-staged": {
-    "{website,src}/**/*.{js,json,css}": ["prettier --write", "git add"],
+    "{website,src}/**/*.{js,json,css}": [
+      "prettier --write",
+      "git add"
+    ],
     "**/*.js": "eslint --max-warnings 0"
   },
   "dependencies": {
@@ -95,7 +98,7 @@
     "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-node-resolve": "^3.0.2",
-    "rollup-plugin-peer-deps-external": "^2.0.0",
+    "rollup-plugin-peer-deps-external": "^2.2.0",
     "rollup-plugin-postcss": "^1.1.0",
     "rollup-plugin-url": "^1.3.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default {
     },
   ],
   plugins: [
-    external(),
+    external({ includeDependencies: true }),
     postcss({
       modules: true,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7026,9 +7026,9 @@ rollup-plugin-node-resolve@^3.0.2:
     is-module "^1.0.0"
     resolve "^1.1.6"
 
-rollup-plugin-peer-deps-external@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.1.1.tgz#49bba4965bedd0b8e1aa613bec4c4ab718b39360"
+rollup-plugin-peer-deps-external@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.0.tgz#99ef9231aa01736f3e9605b7c3084a0d627f665b"
 
 rollup-plugin-postcss@^1.1.0:
   version "1.6.1"


### PR DESCRIPTION
This keeps `memoize-one` as dependency (doesnt bundle it into flat bundles).