### PR TITLE
Annotate components creation with #__PURE__ so they can be DCEed

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
     "react"
   ],
   "plugins": [
+    "annotate-pure-calls",
     "external-helpers"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,8 @@
 {
   "name": "react-window",
   "version": "1.0.1",
-  "description":
-    "React components for efficiently rendering large, scrollable lists and tabular data",
-  "author":
-    "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
+  "description": "React components for efficiently rendering large, scrollable lists and tabular data",
+  "author": "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
   "contributors": [
     "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)"
   ],
@@ -36,7 +34,9 @@
   ],
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "precommit": "lint-staged",
     "prettier": "prettier --write '**/*.{js,json,css}'",
@@ -52,7 +52,10 @@
     "website:run": "cd website && yarn start"
   },
   "lint-staged": {
-    "{website,src}/**/*.{js,json,css}": ["prettier --write", "git add"],
+    "{website,src}/**/*.{js,json,css}": [
+      "prettier --write",
+      "git add"
+    ],
     "**/*.js": "eslint --max-warnings 0"
   },
   "dependencies": {
@@ -65,6 +68,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
+    "babel-plugin-annotate-pure-calls": "^0.3.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,6 +707,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-annotate-pure-calls@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.3.0.tgz#7f0ec500432506a94ff878d6425dce9d043f6902"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
This should make this library tree-shakeable (thanks to uglifyjs dead code elimination)