### PR TITLE
Use explicit constructor in React components

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -167,6 +167,8 @@ export default function createGridComponent({
       verticalScrollDirection: 'forward',
     };
 
+    // always use explicit constructor for React components
+    // it produces less code after transpilation - #26
     constructor(props: Props) {
       super(props);
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -114,7 +114,7 @@ export default function createListComponent({
   validateProps: ValidateProps,
 |}) {
   return class List extends PureComponent<Props, State> {
-    _instanceProps: any = initInstanceProps(this.props, this);
+    _instanceProps: any;
     _itemStyleCache: { [index: number]: Object } = {};
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
@@ -136,6 +136,14 @@ export default function createListComponent({
           : 0,
       scrollUpdateWasRequested: false,
     };
+
+    // always use explicit constructor for React components
+    // it produces less code after transpilation - #26
+    constructor(props: Props) {
+      super(props);
+
+      this._instanceProps = initInstanceProps(props, this);
+    }
 
     static getDerivedStateFromProps(
       nextProps: Props,


### PR DESCRIPTION
This boils down to a fact that `super` has to be called with all arguments if the constructor is not specified (when we use explicit constructor, we explicitly call `super(props)`), so arguments have to be looped and super constructor has to be applied with them.

**Implicit constructor**
```js
var List =
/*#__PURE__*/
function (_PureComponent) {
  _inheritsLoose(List, _PureComponent);

  function List() {
    var _this;

    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
      args[_key] = arguments[_key];
    }

    _this = _PureComponent.call.apply(_PureComponent, [this].concat(args)) || this;
    _this._instanceProps = initInstanceProps(_this.props, _assertThisInitialized(_this));
    return _this;
  }

  return List;
}(PureComponent);
```

**Explicit one**
```js
var List2 =
/*#__PURE__*/
function (_PureComponent2) {
  _inheritsLoose(List2, _PureComponent2);

  function List2(props) {
    var _this2;

    _this2 = _PureComponent2.call(this, props) || this;
    _this2._instanceProps = initInstanceProps(props, _assertThisInitialized(_this2));
    return _this2;
  }

  return List2;
}(PureComponent);
```