### PR TITLE
Distribute flow types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "files": [
-    "dist"
+    "dist",
+    "src/*.js"
   ],
   "scripts": {
     "flow": "flow check src && flow check website",
@@ -45,7 +46,8 @@
     "lint": "eslint '**/*.js'",
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
-    "build": "del dist && rollup -c",
+    "build:flow": "echo \"// @flow\n\nexport * from '../src';\" > dist/index.cjs.js.flow",
+    "build": "del dist && rollup -c && yarn build:flow",
     "start": "rollup -c -w",
     "prepare": "yarn run build",
     "website:build": "cd website && yarn build",


### PR DESCRIPTION
This simple trick works similary to bundling. One file reexports all
sources with its types.

```js
// @flow

export * from '../src';
```