### PR TITLE
Fix misplaced sentences in FixedSizeGrid API docs

### DIFF
--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -87,13 +87,13 @@ const PROPS = [
   },
   {
     defaultValue: 0,
-    description: <p>Vertical scroll offset for initial render.</p>,
+    description: <p>Horizontal scroll offset for initial render.</p>,
     name: 'initialScrollLeft',
     type: 'number',
   },
   {
     defaultValue: 0,
-    description: <p>Horizontal scroll offset for initial render.</p>,
+    description: <p>Vertical scroll offset for initial render.</p>,
     name: 'initialScrollTop',
     type: 'number',
   },


### PR DESCRIPTION
Was reading the docs and noticed a bit confusing description.