### PR TITLE
Remove overflow:hidden from inner container

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -345,7 +345,6 @@ export default function createGridComponent({
           ref: innerRef,
           style: {
             height: estimatedTotalHeight,
-            overflow: 'hidden',
             pointerEvents: isScrolling ? 'none' : '',
             width: estimatedTotalWidth,
           },

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -282,7 +282,6 @@ export default function createListComponent({
           ref: innerRef,
           style: {
             height: direction === 'horizontal' ? '100%' : estimatedTotalSize,
-            overflow: 'hidden',
             pointerEvents: isScrolling ? 'none' : '',
             width: direction === 'horizontal' ? estimatedTotalSize : '100%',
           },


### PR DESCRIPTION
Fixes https://github.com/bvaughn/react-window/issues/55 and allows the use of `position: sticky`. I tested all major browsers and back to IE11 and all seems well.