### PR TITLE
Make itemData generic in grids and lists

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,6 @@
 [lints]
 
 [options]
+include_warnings=true
 
 [strict]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_script:
   - yarn
 script:
   - yarn lint
-  - yarn flow
+  - yarn flow:check
   - yarn test

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "module": "dist/index.esm.js",
   "files": ["dist", "src/*.js"],
   "scripts": {
-    "flow": "flow check src && flow check website",
+    "flow:check": "flow check --max-warnings=0 src && flow check website",
     "precommit": "lint-staged",
     "prettier": "prettier --write '**/*.{js,json,css}'",
     "linc": "lint-staged",

--- a/src/FixedSizeGrid.js
+++ b/src/FixedSizeGrid.js
@@ -5,26 +5,26 @@ import createGridComponent from './createGridComponent';
 import type { Props, ScrollToAlign } from './createGridComponent';
 
 const FixedSizeGrid = createGridComponent({
-  getColumnOffset: ({ columnWidth }: Props, index: number): number =>
+  getColumnOffset: ({ columnWidth }: Props<any>, index: number): number =>
     index * ((columnWidth: any): number),
 
-  getColumnWidth: ({ columnWidth }: Props, index: number): number =>
+  getColumnWidth: ({ columnWidth }: Props<any>, index: number): number =>
     ((columnWidth: any): number),
 
-  getRowOffset: ({ rowHeight }: Props, index: number): number =>
+  getRowOffset: ({ rowHeight }: Props<any>, index: number): number =>
     index * ((rowHeight: any): number),
 
-  getRowHeight: ({ rowHeight }: Props, index: number): number =>
+  getRowHeight: ({ rowHeight }: Props<any>, index: number): number =>
     ((rowHeight: any): number),
 
-  getEstimatedTotalHeight: ({ rowCount, rowHeight }: Props) =>
+  getEstimatedTotalHeight: ({ rowCount, rowHeight }: Props<any>) =>
     ((rowHeight: any): number) * rowCount,
 
-  getEstimatedTotalWidth: ({ columnCount, columnWidth }: Props) =>
+  getEstimatedTotalWidth: ({ columnCount, columnWidth }: Props<any>) =>
     ((columnWidth: any): number) * columnCount,
 
   getOffsetForColumnAndAlignment: (
-    { columnCount, columnWidth, width }: Props,
+    { columnCount, columnWidth, width }: Props<any>,
     columnIndex: number,
     align: ScrollToAlign,
     scrollLeft: number
@@ -63,7 +63,7 @@ const FixedSizeGrid = createGridComponent({
   },
 
   getOffsetForRowAndAlignment: (
-    { rowHeight, height, rowCount }: Props,
+    { rowHeight, height, rowCount }: Props<any>,
     rowIndex: number,
     align: ScrollToAlign,
     scrollTop: number
@@ -102,7 +102,7 @@ const FixedSizeGrid = createGridComponent({
   },
 
   getColumnStartIndexForOffset: (
-    { columnWidth, columnCount }: Props,
+    { columnWidth, columnCount }: Props<any>,
     scrollLeft: number
   ): number =>
     Math.max(
@@ -114,7 +114,7 @@ const FixedSizeGrid = createGridComponent({
     ),
 
   getColumnStopIndexForStartIndex: (
-    { columnWidth, columnCount, width }: Props,
+    { columnWidth, columnCount, width }: Props<any>,
     startIndex: number,
     scrollLeft: number
   ): number => {
@@ -132,7 +132,7 @@ const FixedSizeGrid = createGridComponent({
   },
 
   getRowStartIndexForOffset: (
-    { rowHeight, rowCount }: Props,
+    { rowHeight, rowCount }: Props<any>,
     scrollTop: number
   ): number =>
     Math.max(
@@ -141,7 +141,7 @@ const FixedSizeGrid = createGridComponent({
     ),
 
   getRowStopIndexForStartIndex: (
-    { rowHeight, rowCount, height }: Props,
+    { rowHeight, rowCount, height }: Props<any>,
     startIndex: number,
     scrollTop: number
   ): number => {
@@ -156,13 +156,13 @@ const FixedSizeGrid = createGridComponent({
     );
   },
 
-  initInstanceProps(props: Props): any {
+  initInstanceProps(props: Props<any>): any {
     // Noop
   },
 
   shouldResetStyleCacheOnItemSizeChange: true,
 
-  validateProps: ({ columnWidth, rowHeight }: Props): void => {
+  validateProps: ({ columnWidth, rowHeight }: Props<any>): void => {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof columnWidth !== 'number') {
         throw Error(

--- a/src/FixedSizeList.js
+++ b/src/FixedSizeList.js
@@ -5,17 +5,17 @@ import createListComponent from './createListComponent';
 import type { Props, ScrollToAlign } from './createListComponent';
 
 const FixedSizeList = createListComponent({
-  getItemOffset: ({ itemSize, size }: Props, index: number): number =>
+  getItemOffset: ({ itemSize, size }: Props<any>, index: number): number =>
     index * ((itemSize: any): number),
 
-  getItemSize: ({ itemSize, size }: Props, index: number): number =>
+  getItemSize: ({ itemSize, size }: Props<any>, index: number): number =>
     ((itemSize: any): number),
 
-  getEstimatedTotalSize: ({ itemCount, itemSize }: Props) =>
+  getEstimatedTotalSize: ({ itemCount, itemSize }: Props<any>) =>
     ((itemSize: any): number) * itemCount,
 
   getOffsetForIndexAndAlignment: (
-    { direction, height, itemCount, itemSize, width }: Props,
+    { direction, height, itemCount, itemSize, width }: Props<any>,
     index: number,
     align: ScrollToAlign,
     scrollOffset: number
@@ -53,7 +53,7 @@ const FixedSizeList = createListComponent({
   },
 
   getStartIndexForOffset: (
-    { itemCount, itemSize }: Props,
+    { itemCount, itemSize }: Props<any>,
     offset: number
   ): number =>
     Math.max(
@@ -62,7 +62,7 @@ const FixedSizeList = createListComponent({
     ),
 
   getStopIndexForStartIndex: (
-    { direction, height, itemCount, itemSize, width }: Props,
+    { direction, height, itemCount, itemSize, width }: Props<any>,
     startIndex: number,
     scrollOffset: number
   ): number => {
@@ -80,13 +80,13 @@ const FixedSizeList = createListComponent({
     );
   },
 
-  initInstanceProps(props: Props): any {
+  initInstanceProps(props: Props<any>): any {
     // Noop
   },
 
   shouldResetStyleCacheOnItemSizeChange: true,
 
-  validateProps: ({ itemSize }: Props): void => {
+  validateProps: ({ itemSize }: Props<any>): void => {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof itemSize !== 'number') {
         throw Error(

--- a/src/VariableSizeGrid.js
+++ b/src/VariableSizeGrid.js
@@ -9,7 +9,7 @@ const DEFAULT_ESTIMATED_ITEM_SIZE = 50;
 type VariableSizeProps = {|
   estimatedColumnWidth: number,
   estimatedRowHeight: number,
-  ...Props,
+  ...Props<any>,
 |};
 
 type itemSizeGetter = (index: number) => number;
@@ -30,7 +30,7 @@ type InstanceProps = {|
 |};
 
 const getEstimatedTotalHeight = (
-  { rowCount }: Props,
+  { rowCount }: Props<any>,
   { rowMetadataMap, estimatedRowHeight, lastMeasuredRowIndex }: InstanceProps
 ) => {
   let totalSizeOfMeasuredRows = 0;
@@ -47,7 +47,7 @@ const getEstimatedTotalHeight = (
 };
 
 const getEstimatedTotalWidth = (
-  { columnCount }: Props,
+  { columnCount }: Props<any>,
   {
     columnMetadataMap,
     estimatedColumnWidth,
@@ -69,7 +69,7 @@ const getEstimatedTotalWidth = (
 
 const getItemMetadata = (
   itemType: ItemType,
-  props: Props,
+  props: Props<any>,
   index: number,
   instanceProps: InstanceProps
 ): ItemMetadata => {
@@ -114,7 +114,7 @@ const getItemMetadata = (
 
 const findNearestItem = (
   itemType: ItemType,
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   offset: number
 ) => {
@@ -156,7 +156,7 @@ const findNearestItem = (
 
 const findNearestItemBinarySearch = (
   itemType: ItemType,
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   high: number,
   low: number,
@@ -189,7 +189,7 @@ const findNearestItemBinarySearch = (
 
 const findNearestItemExponentialSearch = (
   itemType: ItemType,
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   index: number,
   offset: number
@@ -217,7 +217,7 @@ const findNearestItemExponentialSearch = (
 
 const getOffsetForIndexAndAlignment = (
   itemType: ItemType,
-  props: Props,
+  props: Props<any>,
   index: number,
   align: ScrollToAlign,
   scrollOffset: number,
@@ -260,19 +260,19 @@ const getOffsetForIndexAndAlignment = (
 
 const VariableSizeGrid = createGridComponent({
   getColumnOffset: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => getItemMetadata('column', props, index, instanceProps).offset,
 
   getColumnStartIndexForOffset: (
-    props: Props,
+    props: Props<any>,
     scrollLeft: number,
     instanceProps: InstanceProps
   ): number => findNearestItem('column', props, instanceProps, scrollLeft),
 
   getColumnStopIndexForStartIndex: (
-    props: Props,
+    props: Props<any>,
     startIndex: number,
     scrollLeft: number,
     instanceProps: InstanceProps
@@ -299,7 +299,7 @@ const VariableSizeGrid = createGridComponent({
   },
 
   getColumnWidth: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => instanceProps.columnMetadataMap[index].size,
@@ -308,7 +308,7 @@ const VariableSizeGrid = createGridComponent({
   getEstimatedTotalWidth,
 
   getOffsetForColumnAndAlignment: (
-    props: Props,
+    props: Props<any>,
     index: number,
     align: ScrollToAlign,
     scrollOffset: number,
@@ -324,7 +324,7 @@ const VariableSizeGrid = createGridComponent({
     ),
 
   getOffsetForRowAndAlignment: (
-    props: Props,
+    props: Props<any>,
     index: number,
     align: ScrollToAlign,
     scrollOffset: number,
@@ -340,25 +340,25 @@ const VariableSizeGrid = createGridComponent({
     ),
 
   getRowOffset: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => getItemMetadata('row', props, index, instanceProps).offset,
 
   getRowHeight: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => instanceProps.rowMetadataMap[index].size,
 
   getRowStartIndexForOffset: (
-    props: Props,
+    props: Props<any>,
     scrollTop: number,
     instanceProps: InstanceProps
   ): number => findNearestItem('row', props, instanceProps, scrollTop),
 
   getRowStopIndexForStartIndex: (
-    props: Props,
+    props: Props<any>,
     startIndex: number,
     scrollTop: number,
     instanceProps: InstanceProps
@@ -384,7 +384,7 @@ const VariableSizeGrid = createGridComponent({
     return stopIndex;
   },
 
-  initInstanceProps(props: Props, instance: any): InstanceProps {
+  initInstanceProps(props: Props<any>, instance: any): InstanceProps {
     const {
       estimatedColumnWidth,
       estimatedRowHeight,
@@ -451,7 +451,7 @@ const VariableSizeGrid = createGridComponent({
 
   shouldResetStyleCacheOnItemSizeChange: false,
 
-  validateProps: ({ columnWidth, rowHeight }: Props): void => {
+  validateProps: ({ columnWidth, rowHeight }: Props<any>): void => {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof columnWidth !== 'function') {
         throw Error(

--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -8,7 +8,7 @@ const DEFAULT_ESTIMATED_ITEM_SIZE = 50;
 
 type VariableSizeProps = {|
   estimatedItemSize: number,
-  ...Props,
+  ...Props<any>,
 |};
 
 type itemSizeGetter = (index: number) => number;
@@ -24,7 +24,7 @@ type InstanceProps = {|
 |};
 
 const getItemMetadata = (
-  props: Props,
+  props: Props<any>,
   index: number,
   instanceProps: InstanceProps
 ): ItemMetadata => {
@@ -56,7 +56,7 @@ const getItemMetadata = (
 };
 
 const findNearestItem = (
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   offset: number
 ) => {
@@ -88,7 +88,7 @@ const findNearestItem = (
 };
 
 const findNearestItemBinarySearch = (
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   high: number,
   low: number,
@@ -115,7 +115,7 @@ const findNearestItemBinarySearch = (
 };
 
 const findNearestItemExponentialSearch = (
-  props: Props,
+  props: Props<any>,
   instanceProps: InstanceProps,
   index: number,
   offset: number
@@ -141,7 +141,7 @@ const findNearestItemExponentialSearch = (
 };
 
 const getEstimatedTotalSize = (
-  { itemCount }: Props,
+  { itemCount }: Props<any>,
   { itemMetadataMap, estimatedItemSize, lastMeasuredIndex }: InstanceProps
 ) => {
   let totalSizeOfMeasuredItems = 0;
@@ -159,13 +159,13 @@ const getEstimatedTotalSize = (
 
 const VariableSizeList = createListComponent({
   getItemOffset: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => getItemMetadata(props, index, instanceProps).offset,
 
   getItemSize: (
-    props: Props,
+    props: Props<any>,
     index: number,
     instanceProps: InstanceProps
   ): number => instanceProps.itemMetadataMap[index].size,
@@ -173,7 +173,7 @@ const VariableSizeList = createListComponent({
   getEstimatedTotalSize,
 
   getOffsetForIndexAndAlignment: (
-    props: Props,
+    props: Props<any>,
     index: number,
     align: ScrollToAlign,
     scrollOffset: number,
@@ -217,13 +217,13 @@ const VariableSizeList = createListComponent({
   },
 
   getStartIndexForOffset: (
-    props: Props,
+    props: Props<any>,
     offset: number,
     instanceProps: InstanceProps
   ): number => findNearestItem(props, instanceProps, offset),
 
   getStopIndexForStartIndex: (
-    props: Props,
+    props: Props<any>,
     startIndex: number,
     scrollOffset: number,
     instanceProps: InstanceProps
@@ -245,7 +245,7 @@ const VariableSizeList = createListComponent({
     return stopIndex;
   },
 
-  initInstanceProps(props: Props, instance: any): InstanceProps {
+  initInstanceProps(props: Props<any>, instance: any): InstanceProps {
     const { estimatedItemSize } = ((props: any): VariableSizeProps);
 
     const instanceProps = {
@@ -279,7 +279,7 @@ const VariableSizeList = createListComponent({
 
   shouldResetStyleCacheOnItemSizeChange: false,
 
-  validateProps: ({ itemSize }: Props): void => {
+  validateProps: ({ itemSize }: Props<any>): void => {
     if (process.env.NODE_ENV !== 'production') {
       if (typeof itemSize !== 'function') {
         throw Error(

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -11,14 +11,14 @@ type ItemKeyGetter = (indices: {
   rowIndex: number,
 }) => any;
 
-type RenderComponentProps = {|
+type RenderComponentProps<T> = {|
   columnIndex: number,
-  data: any,
+  data: T,
   isScrolling?: boolean,
   rowIndex: number,
   style: Object,
 |};
-export type RenderComponent = (props: RenderComponentProps) => React$Node;
+export type RenderComponent<T> = (props: RenderComponentProps<T>) => React$Node;
 
 type ScrollDirection = 'forward' | 'backward';
 
@@ -43,8 +43,8 @@ type OnScrollCallback = ({
 type ScrollEvent = SyntheticEvent<HTMLDivElement>;
 type ItemStyleCache = { [key: string]: Object };
 
-export type Props = {|
-  children: RenderComponent,
+export type Props<T> = {|
+  children: RenderComponent<T>,
   className?: string,
   columnCount: number,
   columnWidth: itemSize,
@@ -53,7 +53,7 @@ export type Props = {|
   initialScrollTop?: number,
   innerRef?: any,
   innerTagName?: string,
-  itemData?: any,
+  itemData: T,
   itemKey?: ItemKeyGetter,
   onItemsRendered?: OnItemsRenderedCallback,
   onScroll?: OnScrollCallback,
@@ -77,32 +77,36 @@ type State = {|
 |};
 
 type getItemOffset = (
-  props: Props,
+  props: Props<any>,
   index: number,
   instanceProps: any
 ) => number;
-type getItemSize = (props: Props, index: number, instanceProps: any) => number;
-type getEstimatedTotalSize = (props: Props, instanceProps: any) => number;
+type getItemSize = (
+  props: Props<any>,
+  index: number,
+  instanceProps: any
+) => number;
+type getEstimatedTotalSize = (props: Props<any>, instanceProps: any) => number;
 type GetOffsetForItemAndAlignment = (
-  props: Props,
+  props: Props<any>,
   index: number,
   align: ScrollToAlign,
   scrollOffset: number,
   instanceProps: any
 ) => number;
 type GetStartIndexForOffset = (
-  props: Props,
+  props: Props<any>,
   offset: number,
   instanceProps: any
 ) => number;
 type GetStopIndexForStartIndex = (
-  props: Props,
+  props: Props<any>,
   startIndex: number,
   scrollOffset: number,
   instanceProps: any
 ) => number;
-type InitInstanceProps = (props: Props, instance: any) => any;
-type ValidateProps = (props: Props) => void;
+type InitInstanceProps = (props: Props<any>, instance: any) => any;
+type ValidateProps = (props: Props<any>) => void;
 
 const IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 
@@ -142,13 +146,14 @@ export default function createGridComponent({
   shouldResetStyleCacheOnItemSizeChange: boolean,
   validateProps: ValidateProps,
 |}) {
-  return class Grid extends PureComponent<Props, State> {
+  return class Grid<T> extends PureComponent<Props<T>, State> {
     _instanceProps: any = initInstanceProps(this.props, this);
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
     _outerRef: ?HTMLDivElement;
 
     static defaultProps = {
       innerTagName: 'div',
+      itemData: undefined,
       outerTagName: 'div',
       overscanCount: 1,
       useIsScrolling: false,
@@ -172,12 +177,12 @@ export default function createGridComponent({
     // Always use explicit constructor for React components.
     // It produces less code after transpilation. (#26)
     // eslint-disable-next-line no-useless-constructor
-    constructor(props: Props) {
+    constructor(props: Props<T>) {
       super(props);
     }
 
     static getDerivedStateFromProps(
-      nextProps: Props,
+      nextProps: Props<T>,
       prevState: State
     ): $Shape<State> {
       validateSharedProps(nextProps);
@@ -637,7 +642,7 @@ export default function createGridComponent({
   };
 }
 
-const validateSharedProps = ({ children, height, width }: Props): void => {
+const validateSharedProps = ({ children, height, width }: Props<any>): void => {
   if (process.env.NODE_ENV !== 'production') {
     if (typeof children !== 'function') {
       throw Error(

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -9,13 +9,13 @@ type itemSize = number | ((index: number) => number);
 type Direction = 'horizontal' | 'vertical';
 type ItemKeyGetter = (index: number) => any;
 
-type RenderComponentProps = {|
-  data: any,
+type RenderComponentProps<T> = {|
+  data: T,
   index: number,
   isScrolling?: boolean,
   style: Object,
 |};
-type RenderComponent = (props: RenderComponentProps) => React$Node;
+type RenderComponent<T> = (props: RenderComponentProps<T>) => React$Node;
 
 type ScrollDirection = 'forward' | 'backward';
 
@@ -34,8 +34,8 @@ type onScrollCallback = ({
 type ScrollEvent = SyntheticEvent<HTMLDivElement>;
 type ItemStyleCache = { [index: number]: Object };
 
-export type Props = {|
-  children: RenderComponent,
+export type Props<T> = {|
+  children: RenderComponent<T>,
   className?: string,
   direction: Direction,
   height: number | string,
@@ -43,7 +43,7 @@ export type Props = {|
   innerRef?: any,
   innerTagName?: string,
   itemCount: number,
-  itemData?: any,
+  itemData: T,
   itemKey?: ItemKeyGetter,
   itemSize: itemSize,
   onItemsRendered?: onItemsRenderedCallback,
@@ -64,32 +64,36 @@ type State = {|
 |};
 
 type GetItemOffset = (
-  props: Props,
+  props: Props<any>,
   index: number,
   instanceProps: any
 ) => number;
-type GetItemSize = (props: Props, index: number, instanceProps: any) => number;
-type GetEstimatedTotalSize = (props: Props, instanceProps: any) => number;
+type GetItemSize = (
+  props: Props<any>,
+  index: number,
+  instanceProps: any
+) => number;
+type GetEstimatedTotalSize = (props: Props<any>, instanceProps: any) => number;
 type GetOffsetForIndexAndAlignment = (
-  props: Props,
+  props: Props<any>,
   index: number,
   align: ScrollToAlign,
   scrollOffset: number,
   instanceProps: any
 ) => number;
 type GetStartIndexForOffset = (
-  props: Props,
+  props: Props<any>,
   offset: number,
   instanceProps: any
 ) => number;
 type GetStopIndexForStartIndex = (
-  props: Props,
+  props: Props<any>,
   startIndex: number,
   scrollOffset: number,
   instanceProps: any
 ) => number;
-type InitInstanceProps = (props: Props, instance: any) => any;
-type ValidateProps = (props: Props) => void;
+type InitInstanceProps = (props: Props<any>, instance: any) => any;
+type ValidateProps = (props: Props<any>) => void;
 
 const IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 
@@ -116,7 +120,7 @@ export default function createListComponent({
   shouldResetStyleCacheOnItemSizeChange: boolean,
   validateProps: ValidateProps,
 |}) {
-  return class List extends PureComponent<Props, State> {
+  return class List<T> extends PureComponent<Props<T>, State> {
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
@@ -124,6 +128,7 @@ export default function createListComponent({
     static defaultProps = {
       direction: 'vertical',
       innerTagName: 'div',
+      itemData: undefined,
       outerTagName: 'div',
       overscanCount: 2,
       useIsScrolling: false,
@@ -142,11 +147,14 @@ export default function createListComponent({
     // Always use explicit constructor for React components.
     // It produces less code after transpilation. (#26)
     // eslint-disable-next-line no-useless-constructor
-    constructor(props: Props) {
+    constructor(props: Props<T>) {
       super(props);
     }
 
-    static getDerivedStateFromProps(props: Props, state: State): $Shape<State> {
+    static getDerivedStateFromProps(
+      props: Props<T>,
+      state: State
+    ): $Shape<State> {
       validateSharedProps(props);
       validateProps(props);
       return null;
@@ -525,7 +533,7 @@ const validateSharedProps = ({
   direction,
   height,
   width,
-}: Props): void => {
+}: Props<any>): void => {
   if (process.env.NODE_ENV !== 'production') {
     if (direction !== 'horizontal' && direction !== 'vertical') {
       throw Error(

--- a/src/test_flow.js
+++ b/src/test_flow.js
@@ -1,0 +1,154 @@
+// @flow
+
+import * as React from 'react';
+import {
+  FixedSizeList,
+  VariableSizeList,
+  FixedSizeGrid,
+  VariableSizeGrid,
+} from './';
+
+const assertVoid = (value: void) => {};
+const assertEmpty = (value: empty) => {};
+const assertNumber = (value: number) => {};
+const assertString = (value: string) => {};
+
+/* FixedSizeList */
+
+{
+  const Item = ({ data }) => {
+    assertNumber(data);
+    // $FlowFixMe number is passed to FixedSizeList
+    assertString(data);
+    return null;
+  };
+  <FixedSizeList width={0} height={0} itemSize={0} itemCount={0} itemData={1}>
+    {Item}
+  </FixedSizeList>;
+}
+
+{
+  const Item = ({ data }) => {
+    assertVoid(data);
+    // $FlowFixMe itemData is undefined by default
+    assertEmpty(data);
+    return null;
+  };
+  <FixedSizeList width={0} height={0} itemSize={0} itemCount={0}>
+    {Item}
+  </FixedSizeList>;
+}
+
+/* VariableSizeList */
+
+{
+  const Item = ({ data }) => {
+    assertNumber(data);
+    // $FlowFixMe number is passed to VariableSizeList
+    assertString(data);
+    return null;
+  };
+  <VariableSizeList
+    width={0}
+    height={0}
+    itemSize={0}
+    itemCount={0}
+    itemData={1}
+  >
+    {Item}
+  </VariableSizeList>;
+}
+
+{
+  const Item = ({ data }) => {
+    assertVoid(data);
+    // $FlowFixMe itemData is undefined by default
+    assertEmpty(data);
+    return null;
+  };
+  <VariableSizeList width={0} height={0} itemSize={0} itemCount={0}>
+    {Item}
+  </VariableSizeList>;
+}
+
+/* FixedSizeGrid */
+
+{
+  const Item = ({ data }) => {
+    assertNumber(data);
+    // $FlowFixMe number is passed to FixedSizeGrid
+    assertString(data);
+    return null;
+  };
+  <FixedSizeGrid
+    width={0}
+    height={0}
+    rowHeight={0}
+    rowCount={0}
+    columnWidth={0}
+    columnCount={0}
+    itemData={1}
+  >
+    {Item}
+  </FixedSizeGrid>;
+}
+
+{
+  const Item = ({ data }) => {
+    assertVoid(data);
+    // $FlowFixMe itemData is undefined by default
+    assertEmpty(data);
+    return null;
+  };
+  <FixedSizeGrid
+    width={0}
+    height={0}
+    rowHeight={0}
+    rowCount={0}
+    columnWidth={0}
+    columnCount={0}
+  >
+    {Item}
+  </FixedSizeGrid>;
+}
+
+/* VariableSizeGrid */
+
+{
+  const Item = ({ data }) => {
+    assertNumber(data);
+    // $FlowFixMe number is passed to VariableSizeGrid
+    assertString(data);
+    return null;
+  };
+  <VariableSizeGrid
+    width={0}
+    height={0}
+    rowHeight={0}
+    rowCount={0}
+    columnWidth={0}
+    columnCount={0}
+    itemData={1}
+  >
+    {Item}
+  </VariableSizeGrid>;
+}
+
+{
+  const Item = ({ data }) => {
+    assertVoid(data);
+    // $FlowFixMe itemData is undefined by default
+    assertEmpty(data);
+    return null;
+  };
+  <VariableSizeGrid
+    width={0}
+    height={0}
+    rowHeight={0}
+    rowCount={0}
+    columnWidth={0}
+    columnCount={0}
+  >
+    {Item}
+  </VariableSizeGrid>;
+}


### PR DESCRIPTION
In this PR I am trying to achieve more sound implementation of itemData
props in all grids and lists.

To prevent `empty` type itemData is made optional with defaultProps.

`flow` script is replaced with `check` to allow running `yarn flow
status` to view all errors and warnings.