### PR TITLE
1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 * 🎉 List and Grid components now "overscan" (pre-render) in both directions when scrolling is not active. When scrolling is in progress, cells are only pre-rendered in the direction being scrolled. This change has been made in an effort to reduce visible flicker when scrolling starts without adding additional overhead during scroll (which is the most performance sensitive time).
 * 🎉 Grid components now support separate `overscanColumnsCount` and `overscanRowsCount` props. Legacy `overscanCount` prop will continue to work, but with a deprecation warning in DEV mode.
 * 🐛 Replaced `setTimeout` with `requestAnimationFrame` based timer, to avoid starvation issue for `isScrolling` reset. - [#106](https://github.com/bvaughn/react-window/issues/106)
+* 🎉 Renamed List and Grid `innerTagName` and `outerTagName` props to `innerElementType` and `outerElementType` to formalize support for attaching arbitrary props (e.g. test ids) to List and Grid inner and outer DOM elements. Legacy `innerTagName` and `outerTagName` props will continue to work, but with a deprecation warning in DEV mode.
 
 ### 1.3.1
 * 🎉 Pass `itemData` value to custom `itemKey` callbacks when present - [#90](https://github.com/bvaughn/react-window/issues/90))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ### 1.4.0
 * 🎉 List and Grid components now "overscan" (pre-render) in both directions when scrolling is not active. When scrolling is in progress, cells are only pre-rendered in the direction being scrolled. This change has been made in an effort to reduce visible flicker when scrolling starts without adding additional overhead during scroll (which is the most performance sensitive time).
 * 🎉 Grid components now support separate `overscanColumnsCount` and `overscanRowsCount` props. Legacy `overscanCount` prop will continue to work, but with a deprecation warning in DEV mode.
+* 🐛 Replaced `setTimeout` with `requestAnimationFrame` based timer, to avoid starvation issue for `isScrolling` reset. - [#106](https://github.com/bvaughn/react-window/issues/106)
 
 ### 1.3.1
 * 🎉 Pass `itemData` value to custom `itemKey` callbacks when present - [#90](https://github.com/bvaughn/react-window/issues/90))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 * 🎉 Grid components now support separate `overscanColumnsCount` and `overscanRowsCount` props. Legacy `overscanCount` prop will continue to work, but with a deprecation warning in DEV mode.
 * 🐛 Replaced `setTimeout` with `requestAnimationFrame` based timer, to avoid starvation issue for `isScrolling` reset. - [#106](https://github.com/bvaughn/react-window/issues/106)
 * 🎉 Renamed List and Grid `innerTagName` and `outerTagName` props to `innerElementType` and `outerElementType` to formalize support for attaching arbitrary props (e.g. test ids) to List and Grid inner and outer DOM elements. Legacy `innerTagName` and `outerTagName` props will continue to work, but with a deprecation warning in DEV mode.
+* 🐛 List re-renders items if `direction` prop changes. - [#104](https://github.com/bvaughn/react-window/issues/104)
 
 ### 1.3.1
 * 🎉 Pass `itemData` value to custom `itemKey` callbacks when present - [#90](https://github.com/bvaughn/react-window/issues/90))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ------------
 
+### 1.4.0
+* 🎉 List and Grid components now "overscan" (pre-render) in both directions when scrolling is not active. When scrolling is in progress, cells are only pre-rendered in the direction being scrolled. This change has been made in an effort to reduce visible flicker when scrolling starts without adding additional overhead during scroll (which is the most performance sensitive time).
+* 🎉 Grid components now support separate `overscanColumnsCount` and `overscanRowsCount` props. Legacy `overscanCount` prop will continue to work, but with a deprecation warning in DEV mode.
+
 ### 1.3.1
 * 🎉 Pass `itemData` value to custom `itemKey` callbacks when present - [#90](https://github.com/bvaughn/react-window/issues/90))
 

--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent } from 'react';
+import React, { createRef, forwardRef, PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -686,19 +686,54 @@ describe('FixedSizeGrid', () => {
     });
   });
 
-  describe('custom tag names', () => {
-    it('should use a custom innerTagName if specified', () => {
+  describe('custom element types', () => {
+    it('should use a custom innerElementType if specified', () => {
       const rendered = ReactTestRenderer.create(
-        <FixedSizeGrid {...defaultProps} innerTagName="section" />
+        <FixedSizeGrid {...defaultProps} innerElementType="section" />
       );
       expect(rendered.root.findByType('section')).toBeDefined();
     });
 
-    it('should use a custom outerTagName if specified', () => {
+    it('should use a custom outerElementType if specified', () => {
       const rendered = ReactTestRenderer.create(
-        <FixedSizeGrid {...defaultProps} outerTagName="section" />
+        <FixedSizeGrid {...defaultProps} outerElementType="section" />
       );
       expect(rendered.root.findByType('section')).toBeDefined();
+    });
+
+    it('should support spreading additional, arbitrary props, e.g. id', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <FixedSizeGrid
+          {...defaultProps}
+          innerElementType={forwardRef((props, ref) => (
+            <div ref={ref} id="inner" {...props} />
+          ))}
+          outerElementType={forwardRef((props, ref) => (
+            <div ref={ref} id="outer" {...props} />
+          ))}
+        />,
+        container
+      );
+      expect(container.firstChild.id).toBe('outer');
+      expect(container.firstChild.firstChild.id).toBe('inner');
+    });
+
+    it('should warn if legacy innerTagName or outerTagName props are used', () => {
+      spyOn(console, 'warn');
+      ReactDOM.render(
+        <FixedSizeGrid
+          {...defaultProps}
+          innerTagName="div"
+          outerTagName="div"
+        />,
+        document.createElement('div')
+      );
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenLastCalledWith(
+        'The innerTagName and outerTagName props have been deprecated. ' +
+          'Please use the innerElementType and outerElementType props instead.'
+      );
     });
   });
 

--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -172,14 +172,15 @@ describe('FixedSizeGrid', () => {
     });
   });
 
-  describe('overscanCount', () => {
+  describe('overscanColumnsCount and overscanRowsCount', () => {
     it('should require a minimum of 1 overscan to support tabbing', () => {
       ReactTestRenderer.create(
         <FixedSizeGrid
           {...defaultProps}
           initialScrollLeft={250}
           initialScrollTop={250}
-          overscanCount={0}
+          overscanColumnsCount={0}
+          overscanRowsCount={0}
         />
       );
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
@@ -191,7 +192,8 @@ describe('FixedSizeGrid', () => {
           {...defaultProps}
           initialScrollLeft={250}
           initialScrollTop={250}
-          overscanCount={2}
+          overscanColumnsCount={2}
+          overscanRowsCount={2}
         />
       );
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
@@ -203,7 +205,8 @@ describe('FixedSizeGrid', () => {
           {...defaultProps}
           initialScrollLeft={250}
           initialScrollTop={250}
-          overscanCount={2}
+          overscanColumnsCount={2}
+          overscanRowsCount={2}
         />
       );
       rendered.getInstance().scrollTo({ scrollLeft: 1000, scrollTop: 1000 });
@@ -227,6 +230,61 @@ describe('FixedSizeGrid', () => {
         />
       );
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    describe('overscanCount', () => {
+      it('should warn about deprecated overscanCount prop', () => {
+        spyOn(console, 'warn');
+        ReactTestRenderer.create(
+          <FixedSizeGrid {...defaultProps} overscanCount={1} />
+        );
+        expect(console.warn).toHaveBeenCalledTimes(1);
+        expect(console.warn).toHaveBeenLastCalledWith(
+          'The overscanCount prop has been deprecated. ' +
+            'Please use the overscanColumnsCount and overscanRowsCount props instead.'
+        );
+      });
+
+      it('should use overscanColumnsCount if both it and overscanCount are provided', () => {
+        spyOn(console, 'warn');
+        ReactTestRenderer.create(
+          <FixedSizeGrid
+            {...defaultProps}
+            initialScrollLeft={100}
+            initialScrollTop={100}
+            overscanColumnsCount={3}
+            overscanCount={2}
+          />
+        );
+        expect(onItemsRendered.mock.calls).toMatchSnapshot();
+      });
+
+      it('should use overscanRowsCount if both it and overscanCount are provided', () => {
+        spyOn(console, 'warn');
+        ReactTestRenderer.create(
+          <FixedSizeGrid
+            {...defaultProps}
+            initialScrollLeft={100}
+            initialScrollTop={100}
+            overscanCount={2}
+            overscanRowsCount={3}
+          />
+        );
+        expect(onItemsRendered.mock.calls).toMatchSnapshot();
+      });
+
+      it('should support deprecated overscanCount', () => {
+        spyOn(console, 'warn');
+        ReactTestRenderer.create(
+          <FixedSizeGrid
+            {...defaultProps}
+            initialScrollLeft={100}
+            initialScrollTop={100}
+            overscanCount={2}
+          />
+        );
+        expect(onItemsRendered.mock.calls).toMatchSnapshot();
+      });
     });
   });
 

--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -186,19 +186,6 @@ describe('FixedSizeGrid', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
-    it('should accommodate a custom overscan', () => {
-      ReactTestRenderer.create(
-        <FixedSizeGrid
-          {...defaultProps}
-          initialScrollLeft={250}
-          initialScrollTop={250}
-          overscanColumnsCount={2}
-          overscanRowsCount={2}
-        />
-      );
-      expect(onItemsRendered.mock.calls).toMatchSnapshot();
-    });
-
     it('should overscan in the direction being scrolled', () => {
       const rendered = ReactTestRenderer.create(
         <FixedSizeGrid
@@ -211,6 +198,32 @@ describe('FixedSizeGrid', () => {
       );
       rendered.getInstance().scrollTo({ scrollLeft: 1000, scrollTop: 1000 });
       rendered.getInstance().scrollTo({ scrollLeft: 500, scrollTop: 500 });
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('should overscan in both directions when not scrolling', () => {
+      ReactTestRenderer.create(
+        <FixedSizeGrid
+          {...defaultProps}
+          initialScrollLeft={250}
+          initialScrollTop={250}
+          overscanColumnsCount={2}
+          overscanRowsCount={2}
+        />
+      );
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('should accommodate a custom overscan', () => {
+      ReactTestRenderer.create(
+        <FixedSizeGrid
+          {...defaultProps}
+          initialScrollLeft={250}
+          initialScrollTop={250}
+          overscanColumnsCount={2}
+          overscanRowsCount={2}
+        />
+      );
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -198,27 +198,36 @@ describe('FixedSizeList', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
-    it('should accommodate a custom overscan', () => {
-      ReactTestRenderer.create(
+    it('should overscan in the direction being scrolled', () => {
+      const instance = ReactDOM.render(
         <FixedSizeList
           {...defaultProps}
           initialScrollOffset={50}
           overscanCount={2}
-        />
+        />,
+        document.createElement('div')
+      );
+      // Simulate scrolling (rather than using scrollTo) to test isScrolling state.
+      simulateScroll(instance, 100);
+      simulateScroll(instance, 50);
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('should overscan in both directions when not scrolling', () => {
+      ReactTestRenderer.create(
+        <FixedSizeList {...defaultProps} initialScrollOffset={50} />
       );
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
-    it('should overscan in the direction being scrolled', () => {
-      const rendered = ReactTestRenderer.create(
+    it('should accommodate a custom overscan', () => {
+      ReactTestRenderer.create(
         <FixedSizeList
           {...defaultProps}
-          initialScrollOffset={50}
-          overscanCount={2}
+          initialScrollOffset={100}
+          overscanCount={3}
         />
       );
-      rendered.getInstance().scrollTo(100);
-      rendered.getInstance().scrollTo(50);
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -265,7 +274,7 @@ describe('FixedSizeList', () => {
     it('should not re-render children unnecessarily if isScrolling param is not used', () => {
       // Use ReactDOM renderer so the container ref and "onScroll" work correctly.
       const instance = ReactDOM.render(
-        <FixedSizeList {...defaultProps} />,
+        <FixedSizeList {...defaultProps} overscanCount={1} />,
         document.createElement('div')
       );
       simulateScroll(instance, 100);

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent } from 'react';
+import React, { createRef, forwardRef, PureComponent } from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
@@ -532,19 +532,54 @@ describe('FixedSizeList', () => {
     });
   });
 
-  describe('custom tag names', () => {
-    it('should use a custom innerTagName if specified', () => {
+  describe('custom element types', () => {
+    it('should use a custom innerElementType if specified', () => {
       const rendered = ReactTestRenderer.create(
-        <FixedSizeList {...defaultProps} innerTagName="section" />
+        <FixedSizeList {...defaultProps} innerElementType="section" />
       );
       expect(rendered.root.findByType('section')).toBeDefined();
     });
 
-    it('should use a custom outerTagName if specified', () => {
+    it('should use a custom outerElementType if specified', () => {
       const rendered = ReactTestRenderer.create(
-        <FixedSizeList {...defaultProps} outerTagName="section" />
+        <FixedSizeList {...defaultProps} outerElementType="section" />
       );
       expect(rendered.root.findByType('section')).toBeDefined();
+    });
+
+    it('should support spreading additional, arbitrary props, e.g. id', () => {
+      const container = document.createElement('div');
+      ReactDOM.render(
+        <FixedSizeList
+          {...defaultProps}
+          innerElementType={forwardRef((props, ref) => (
+            <div ref={ref} id="inner" {...props} />
+          ))}
+          outerElementType={forwardRef((props, ref) => (
+            <div ref={ref} id="outer" {...props} />
+          ))}
+        />,
+        container
+      );
+      expect(container.firstChild.id).toBe('outer');
+      expect(container.firstChild.firstChild.id).toBe('inner');
+    });
+
+    it('should warn if legacy innerTagName or outerTagName props are used', () => {
+      spyOn(console, 'warn');
+      ReactDOM.render(
+        <FixedSizeList
+          {...defaultProps}
+          innerTagName="div"
+          outerTagName="div"
+        />,
+        document.createElement('div')
+      );
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenLastCalledWith(
+        'The innerTagName and outerTagName props have been deprecated. ' +
+          'Please use the innerElementType and outerElementType props instead.'
+      );
     });
   });
 

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -64,6 +64,22 @@ describe('FixedSizeList', () => {
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
+  it('should re-render items if direction changes', () => {
+    const rendered = ReactTestRenderer.create(
+      <FixedSizeList {...defaultProps} direction="vertical" />
+    );
+    expect(itemRenderer).toHaveBeenCalled();
+    itemRenderer.mockClear();
+
+    // Re-rendering should not affect pure sCU children:
+    rendered.update(<FixedSizeList {...defaultProps} direction="vertical" />);
+    expect(itemRenderer).not.toHaveBeenCalled();
+
+    // Re-rendering with new direction should re-render children:
+    rendered.update(<FixedSizeList {...defaultProps} direction="horizontal" />);
+    expect(itemRenderer).toHaveBeenCalled();
+  });
+
   describe('scrollbar handling', () => {
     it('should set width to "100%" for vertical lists to avoid unnecessary horizontal scrollbar', () => {
       const innerRef = createRef();

--- a/src/__tests__/VariableSizeGrid.js
+++ b/src/__tests__/VariableSizeGrid.js
@@ -89,7 +89,8 @@ describe('VariableSizeGrid', () => {
           columnWidth={columnWidth}
           estimatedColumnWidth={200}
           estimatedRowHeight={100}
-          overscanCount={0}
+          overscanColumnsCount={0}
+          overscanRowsCount={0}
           rowCount={50}
           rowHeight={rowHeight}
         />
@@ -113,7 +114,8 @@ describe('VariableSizeGrid', () => {
           columnWidth={columnWidth}
           estimatedColumnWidth={200}
           estimatedRowHeight={100}
-          overscanCount={0}
+          overscanColumnsCount={0}
+          overscanRowsCount={0}
           rowCount={50}
           rowHeight={rowHeight}
         />
@@ -293,7 +295,8 @@ describe('VariableSizeGrid', () => {
           {...defaultProps}
           estimatedColumnWidth={30}
           estimatedRowHeight={30}
-          overscanCount={1}
+          overscanColumnsCount={1}
+          overscanRowsCount={1}
           columnWidth={index => 50}
           rowHeight={index => 25}
         />
@@ -311,7 +314,8 @@ describe('VariableSizeGrid', () => {
           {...defaultProps}
           estimatedColumnWidth={30}
           estimatedRowHeight={30}
-          overscanCount={1}
+          overscanColumnsCount={1}
+          overscanRowsCount={1}
           columnWidth={index => 40}
           rowHeight={index => 20}
         />
@@ -333,7 +337,8 @@ describe('VariableSizeGrid', () => {
           {...defaultProps}
           estimatedColumnWidth={30}
           estimatedRowHeight={30}
-          overscanCount={1}
+          overscanColumnsCount={1}
+          overscanRowsCount={1}
           columnWidth={index => 40}
           rowHeight={index => 20}
         />

--- a/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
@@ -96,7 +96,58 @@ Array [
 ]
 `;
 
-exports[`FixedSizeGrid overscanCount should accommodate a custom overscan 1`] = `
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount overscanCount should support deprecated overscanCount 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 3,
+      "overscanRowStopIndex": 10,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 4,
+      "visibleRowStopIndex": 8,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount overscanCount should use overscanColumnsCount if both it and overscanCount are provided 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 6,
+      "overscanRowStartIndex": 3,
+      "overscanRowStopIndex": 10,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 4,
+      "visibleRowStopIndex": 8,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount overscanCount should use overscanRowsCount if both it and overscanCount are provided 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 3,
+      "overscanRowStopIndex": 11,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 4,
+      "visibleRowStopIndex": 8,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should accommodate a custom overscan 1`] = `
 Array [
   Array [
     Object {
@@ -113,7 +164,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeGrid overscanCount should not scan past the beginning of the grid 1`] = `
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should not scan past the beginning of the grid 1`] = `
 Array [
   Array [
     Object {
@@ -130,7 +181,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeGrid overscanCount should not scan past the end of the grid 1`] = `
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should not scan past the end of the grid 1`] = `
 Array [
   Array [
     Object {
@@ -147,7 +198,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeGrid overscanCount should overscan in the direction being scrolled 1`] = `
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should overscan in the direction being scrolled 1`] = `
 Array [
   Array [
     Object {
@@ -188,7 +239,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeGrid overscanCount should require a minimum of 1 overscan to support tabbing 1`] = `
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should require a minimum of 1 overscan to support tabbing 1`] = `
 Array [
   Array [
     Object {

--- a/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
@@ -102,7 +102,7 @@ Array [
     Object {
       "overscanColumnStartIndex": 0,
       "overscanColumnStopIndex": 5,
-      "overscanRowStartIndex": 3,
+      "overscanRowStartIndex": 2,
       "overscanRowStopIndex": 10,
       "visibleColumnStartIndex": 1,
       "visibleColumnStopIndex": 3,
@@ -119,7 +119,7 @@ Array [
     Object {
       "overscanColumnStartIndex": 0,
       "overscanColumnStopIndex": 6,
-      "overscanRowStartIndex": 3,
+      "overscanRowStartIndex": 2,
       "overscanRowStopIndex": 10,
       "visibleColumnStartIndex": 1,
       "visibleColumnStopIndex": 3,
@@ -136,7 +136,7 @@ Array [
     Object {
       "overscanColumnStartIndex": 0,
       "overscanColumnStopIndex": 5,
-      "overscanRowStartIndex": 3,
+      "overscanRowStartIndex": 1,
       "overscanRowStopIndex": 11,
       "visibleColumnStartIndex": 1,
       "visibleColumnStopIndex": 3,
@@ -151,9 +151,9 @@ exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should accommo
 Array [
   Array [
     Object {
-      "overscanColumnStartIndex": 1,
+      "overscanColumnStartIndex": 0,
       "overscanColumnStopIndex": 6,
-      "overscanRowStartIndex": 9,
+      "overscanRowStartIndex": 8,
       "overscanRowStopIndex": 16,
       "visibleColumnStartIndex": 2,
       "visibleColumnStopIndex": 4,
@@ -198,13 +198,30 @@ Array [
 ]
 `;
 
+exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should overscan in both directions when not scrolling 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 6,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 16,
+      "visibleColumnStartIndex": 2,
+      "visibleColumnStopIndex": 4,
+      "visibleRowStartIndex": 10,
+      "visibleRowStopIndex": 14,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeGrid overscanColumnsCount and overscanRowsCount should overscan in the direction being scrolled 1`] = `
 Array [
   Array [
     Object {
-      "overscanColumnStartIndex": 1,
+      "overscanColumnStartIndex": 0,
       "overscanColumnStopIndex": 6,
-      "overscanRowStartIndex": 9,
+      "overscanRowStartIndex": 8,
       "overscanRowStopIndex": 16,
       "visibleColumnStartIndex": 2,
       "visibleColumnStopIndex": 4,
@@ -214,9 +231,9 @@ Array [
   ],
   Array [
     Object {
-      "overscanColumnStartIndex": 9,
+      "overscanColumnStartIndex": 8,
       "overscanColumnStopIndex": 14,
-      "overscanRowStartIndex": 39,
+      "overscanRowStartIndex": 38,
       "overscanRowStopIndex": 46,
       "visibleColumnStartIndex": 10,
       "visibleColumnStopIndex": 12,
@@ -227,9 +244,9 @@ Array [
   Array [
     Object {
       "overscanColumnStartIndex": 3,
-      "overscanColumnStopIndex": 8,
+      "overscanColumnStopIndex": 9,
       "overscanRowStartIndex": 18,
-      "overscanRowStopIndex": 25,
+      "overscanRowStopIndex": 26,
       "visibleColumnStartIndex": 5,
       "visibleColumnStopIndex": 7,
       "visibleRowStartIndex": 20,

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -64,9 +64,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 1,
-      "overscanStopIndex": 8,
-      "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "overscanStopIndex": 11,
+      "visibleStartIndex": 4,
+      "visibleStopIndex": 8,
     },
   ],
 ]
@@ -89,10 +89,23 @@ exports[`FixedSizeList overscanCount should not scan past the end of the list 1`
 Array [
   Array [
     Object {
-      "overscanStartIndex": 5,
+      "overscanStartIndex": 4,
       "overscanStopIndex": 9,
       "visibleStartIndex": 6,
       "visibleStopIndex": 9,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList overscanCount should overscan in both directions when not scrolling 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 8,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
     },
   ],
 ]
@@ -102,7 +115,7 @@ exports[`FixedSizeList overscanCount should overscan in the direction being scro
 Array [
   Array [
     Object {
-      "overscanStartIndex": 1,
+      "overscanStartIndex": 0,
       "overscanStopIndex": 8,
       "visibleStartIndex": 2,
       "visibleStopIndex": 6,
@@ -152,7 +165,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 6,
+      "overscanStartIndex": 5,
       "overscanStopIndex": 13,
       "visibleStartIndex": 7,
       "visibleStopIndex": 11,
@@ -160,16 +173,8 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 5,
-      "overscanStopIndex": 12,
-      "visibleStartIndex": 7,
-      "visibleStopIndex": 11,
-    },
-  ],
-  Array [
-    Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 7,
+      "overscanStopIndex": 8,
       "visibleStartIndex": 2,
       "visibleStopIndex": 6,
     },
@@ -189,7 +194,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 7,
+      "overscanStartIndex": 6,
       "overscanStopIndex": 14,
       "visibleStartIndex": 8,
       "visibleStopIndex": 12,
@@ -198,7 +203,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 5,
-      "overscanStopIndex": 12,
+      "overscanStopIndex": 13,
       "visibleStartIndex": 7,
       "visibleStopIndex": 11,
     },
@@ -206,14 +211,14 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 5,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 0,
       "visibleStopIndex": 4,
     },
   ],
   Array [
     Object {
-      "overscanStartIndex": 95,
+      "overscanStartIndex": 94,
       "overscanStopIndex": 99,
       "visibleStartIndex": 96,
       "visibleStopIndex": 99,
@@ -234,7 +239,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 6,
+      "overscanStartIndex": 5,
       "overscanStopIndex": 13,
       "visibleStartIndex": 7,
       "visibleStopIndex": 11,
@@ -243,7 +248,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 4,
-      "overscanStopIndex": 11,
+      "overscanStopIndex": 12,
       "visibleStartIndex": 6,
       "visibleStopIndex": 10,
     },
@@ -251,7 +256,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 5,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 0,
       "visibleStopIndex": 4,
     },
@@ -271,7 +276,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 9,
+      "overscanStartIndex": 8,
       "overscanStopIndex": 16,
       "visibleStartIndex": 10,
       "visibleStopIndex": 14,
@@ -280,14 +285,14 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 7,
-      "overscanStopIndex": 14,
+      "overscanStopIndex": 15,
       "visibleStartIndex": 9,
       "visibleStopIndex": 13,
     },
   ],
   Array [
     Object {
-      "overscanStartIndex": 95,
+      "overscanStartIndex": 94,
       "overscanStopIndex": 99,
       "visibleStartIndex": 96,
       "visibleStopIndex": 99,

--- a/src/__tests__/__snapshots__/VariableSizeList.js.snap
+++ b/src/__tests__/__snapshots__/VariableSizeList.js.snap
@@ -12,7 +12,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 7,
+      "overscanStartIndex": 6,
       "overscanStopIndex": 12,
       "visibleStartIndex": 8,
       "visibleStopIndex": 10,
@@ -20,16 +20,8 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 6,
-      "overscanStopIndex": 11,
-      "visibleStartIndex": 8,
-      "visibleStopIndex": 10,
-    },
-  ],
-  Array [
-    Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 7,
       "visibleStartIndex": 2,
       "visibleStopIndex": 5,
     },
@@ -49,7 +41,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 8,
+      "overscanStartIndex": 7,
       "overscanStopIndex": 13,
       "visibleStartIndex": 9,
       "visibleStopIndex": 11,
@@ -58,7 +50,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 6,
-      "overscanStopIndex": 11,
+      "overscanStopIndex": 12,
       "visibleStartIndex": 8,
       "visibleStopIndex": 10,
     },
@@ -66,7 +58,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 5,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 0,
       "visibleStopIndex": 4,
     },
@@ -86,7 +78,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 8,
+      "overscanStartIndex": 7,
       "overscanStopIndex": 13,
       "visibleStartIndex": 9,
       "visibleStopIndex": 11,
@@ -95,7 +87,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 6,
-      "overscanStopIndex": 11,
+      "overscanStopIndex": 12,
       "visibleStartIndex": 8,
       "visibleStopIndex": 10,
     },
@@ -103,14 +95,14 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 5,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 0,
       "visibleStopIndex": 4,
     },
   ],
   Array [
     Object {
-      "overscanStartIndex": 16,
+      "overscanStartIndex": 15,
       "overscanStopIndex": 19,
       "visibleStartIndex": 17,
       "visibleStopIndex": 19,
@@ -131,7 +123,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 7,
+      "overscanStartIndex": 6,
       "overscanStopIndex": 12,
       "visibleStartIndex": 8,
       "visibleStopIndex": 10,
@@ -140,7 +132,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 4,
-      "overscanStopIndex": 10,
+      "overscanStopIndex": 11,
       "visibleStartIndex": 6,
       "visibleStopIndex": 9,
     },
@@ -148,7 +140,7 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 4,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
       "visibleStopIndex": 3,
     },
@@ -168,7 +160,7 @@ Array [
   ],
   Array [
     Object {
-      "overscanStartIndex": 9,
+      "overscanStartIndex": 8,
       "overscanStopIndex": 14,
       "visibleStartIndex": 10,
       "visibleStopIndex": 12,
@@ -177,14 +169,14 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 7,
-      "overscanStopIndex": 12,
+      "overscanStopIndex": 13,
       "visibleStartIndex": 9,
       "visibleStopIndex": 11,
     },
   ],
   Array [
     Object {
-      "overscanStartIndex": 16,
+      "overscanStartIndex": 15,
       "overscanStopIndex": 19,
       "visibleStartIndex": 17,
       "visibleStopIndex": 19,

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -510,7 +510,7 @@ export default function createGridComponent({
         overscanCount,
         rowCount,
       } = this.props;
-      const { horizontalScrollDirection, scrollLeft } = this.state;
+      const { horizontalScrollDirection, isScrolling, scrollLeft } = this.state;
 
       const overscanCountResolved: number =
         overscanColumnsCount || overscanCount || 1;
@@ -534,11 +534,11 @@ export default function createGridComponent({
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
-        horizontalScrollDirection === 'backward'
+        !isScrolling || horizontalScrollDirection === 'backward'
           ? Math.max(1, overscanCountResolved)
           : 1;
       const overscanForward =
-        horizontalScrollDirection === 'forward'
+        !isScrolling || horizontalScrollDirection === 'forward'
           ? Math.max(1, overscanCountResolved)
           : 1;
 
@@ -557,7 +557,7 @@ export default function createGridComponent({
         overscanRowsCount,
         rowCount,
       } = this.props;
-      const { verticalScrollDirection, scrollTop } = this.state;
+      const { isScrolling, verticalScrollDirection, scrollTop } = this.state;
 
       const overscanCountResolved: number =
         overscanRowsCount || overscanCount || 1;
@@ -581,11 +581,11 @@ export default function createGridComponent({
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
-        verticalScrollDirection === 'backward'
+        !isScrolling || verticalScrollDirection === 'backward'
           ? Math.max(1, overscanCountResolved)
           : 1;
       const overscanForward =
-        verticalScrollDirection === 'forward'
+        !isScrolling || verticalScrollDirection === 'forward'
           ? Math.max(1, overscanCountResolved)
           : 1;
 

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -2,6 +2,9 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
+import { cancelTimeout, requestTimeout } from './timer';
+
+import type { TimeoutID } from './timer';
 
 export type ScrollToAlign = 'auto' | 'center' | 'start' | 'end';
 
@@ -273,7 +276,7 @@ export default function createGridComponent({
 
     componentWillUnmount() {
       if (this._resetIsScrollingTimeoutId !== null) {
-        clearTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId);
       }
     }
 
@@ -641,21 +644,10 @@ export default function createGridComponent({
 
     _resetIsScrollingDebounced = () => {
       if (this._resetIsScrollingTimeoutId !== null) {
-        clearTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId);
       }
 
-      this._resetIsScrollingTimeoutId = setTimeout(
-        this._resetIsScrolling,
-        IS_SCROLLING_DEBOUNCE_INTERVAL
-      );
-    };
-
-    _resetIsScrollingDebounced = () => {
-      if (this._resetIsScrollingTimeoutId !== null) {
-        clearTimeout(this._resetIsScrollingTimeoutId);
-      }
-
-      this._resetIsScrollingTimeoutId = setTimeout(
+      this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
         IS_SCROLLING_DEBOUNCE_INTERVAL
       );

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -53,7 +53,8 @@ export type Props<T> = {|
   initialScrollLeft?: number,
   initialScrollTop?: number,
   innerRef?: any,
-  innerTagName?: string,
+  innerElementType?: React$ElementType,
+  innerTagName?: string, // deprecated
   itemData: T,
   itemKey?: (params: {|
     columnIndex: number,
@@ -63,7 +64,8 @@ export type Props<T> = {|
   onItemsRendered?: OnItemsRenderedCallback,
   onScroll?: OnScrollCallback,
   outerRef?: any,
-  outerTagName?: string,
+  outerElementType?: React$ElementType,
+  outerTagName?: string, // deprecated
   overscanColumnsCount?: number,
   overscanCount?: number, // deprecated
   overscanRowsCount?: number,
@@ -159,9 +161,7 @@ export default function createGridComponent({
     _outerRef: ?HTMLDivElement;
 
     static defaultProps = {
-      innerTagName: 'div',
       itemData: undefined,
-      outerTagName: 'div',
       useIsScrolling: false,
     };
 
@@ -287,9 +287,11 @@ export default function createGridComponent({
         columnCount,
         height,
         innerRef,
+        innerElementType,
         innerTagName,
         itemData,
         itemKey = defaultItemKey,
+        outerElementType,
         outerTagName,
         rowCount,
         style,
@@ -342,7 +344,7 @@ export default function createGridComponent({
       );
 
       return createElement(
-        ((outerTagName: any): string),
+        outerElementType || outerTagName || 'div',
         {
           className,
           onScroll: this._onScroll,
@@ -357,7 +359,7 @@ export default function createGridComponent({
             ...style,
           },
         },
-        createElement(((innerTagName: any): string), {
+        createElement(innerElementType || innerTagName || 'div', {
           children: items,
           ref: innerRef,
           style: {
@@ -668,6 +670,8 @@ export default function createGridComponent({
 const validateSharedProps = ({
   children,
   height,
+  innerTagName,
+  outerTagName,
   overscanCount,
   width,
 }: Props<any>): void => {
@@ -676,6 +680,13 @@ const validateSharedProps = ({
       console.warn(
         'The overscanCount prop has been deprecated. ' +
           'Please use the overscanColumnsCount and overscanRowsCount props instead.'
+      );
+    }
+
+    if (innerTagName != null || outerTagName != null) {
+      console.warn(
+        'The innerTagName and outerTagName props have been deprecated. ' +
+          'Please use the innerElementType and outerElementType props instead.'
       );
     }
 

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -61,7 +61,9 @@ export type Props<T> = {|
   onScroll?: OnScrollCallback,
   outerRef?: any,
   outerTagName?: string,
-  overscanCount: number,
+  overscanColumnsCount?: number,
+  overscanCount?: number, // deprecated
+  overscanRowsCount?: number,
   rowCount: number,
   rowHeight: itemSize,
   style?: Object,
@@ -157,7 +159,6 @@ export default function createGridComponent({
       innerTagName: 'div',
       itemData: undefined,
       outerTagName: 'div',
-      overscanCount: 1,
       useIsScrolling: false,
     };
 
@@ -503,8 +504,16 @@ export default function createGridComponent({
     _getItemStyleCache = memoizeOne((_: any, __: any) => ({}));
 
     _getHorizontalRangeToRender(): [number, number, number, number] {
-      const { columnCount, overscanCount, rowCount } = this.props;
+      const {
+        columnCount,
+        overscanColumnsCount,
+        overscanCount,
+        rowCount,
+      } = this.props;
       const { horizontalScrollDirection, scrollLeft } = this.state;
+
+      const overscanCountResolved: number =
+        overscanColumnsCount || overscanCount || 1;
 
       if (columnCount === 0 || rowCount === 0) {
         return [0, 0, 0, 0];
@@ -526,11 +535,11 @@ export default function createGridComponent({
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
         horizontalScrollDirection === 'backward'
-          ? Math.max(1, overscanCount)
+          ? Math.max(1, overscanCountResolved)
           : 1;
       const overscanForward =
         horizontalScrollDirection === 'forward'
-          ? Math.max(1, overscanCount)
+          ? Math.max(1, overscanCountResolved)
           : 1;
 
       return [
@@ -542,8 +551,16 @@ export default function createGridComponent({
     }
 
     _getVerticalRangeToRender(): [number, number, number, number] {
-      const { columnCount, rowCount, overscanCount } = this.props;
+      const {
+        columnCount,
+        overscanCount,
+        overscanRowsCount,
+        rowCount,
+      } = this.props;
       const { verticalScrollDirection, scrollTop } = this.state;
+
+      const overscanCountResolved: number =
+        overscanRowsCount || overscanCount || 1;
 
       if (columnCount === 0 || rowCount === 0) {
         return [0, 0, 0, 0];
@@ -564,9 +581,13 @@ export default function createGridComponent({
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
-        verticalScrollDirection === 'backward' ? Math.max(1, overscanCount) : 1;
+        verticalScrollDirection === 'backward'
+          ? Math.max(1, overscanCountResolved)
+          : 1;
       const overscanForward =
-        verticalScrollDirection === 'forward' ? Math.max(1, overscanCount) : 1;
+        verticalScrollDirection === 'forward'
+          ? Math.max(1, overscanCountResolved)
+          : 1;
 
       return [
         Math.max(0, startIndex - overscanBackward),
@@ -652,8 +673,20 @@ export default function createGridComponent({
   };
 }
 
-const validateSharedProps = ({ children, height, width }: Props<any>): void => {
+const validateSharedProps = ({
+  children,
+  height,
+  overscanCount,
+  width,
+}: Props<any>): void => {
   if (process.env.NODE_ENV !== 'production') {
+    if (typeof overscanCount === 'number') {
+      console.warn(
+        'The overscanCount prop has been deprecated. ' +
+          'Please use the overscanColumnsCount and overscanRowsCount props instead.'
+      );
+    }
+
     if (children == null) {
       throw Error(
         'An invalid "children" prop has been specified. ' +

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -382,7 +382,8 @@ export default function createListComponent({
       const { direction, itemSize } = this.props;
 
       const itemStyleCache = this._getItemStyleCache(
-        shouldResetStyleCacheOnItemSizeChange && itemSize
+        shouldResetStyleCacheOnItemSizeChange && itemSize,
+        shouldResetStyleCacheOnItemSizeChange && direction
       );
 
       let style;
@@ -413,8 +414,8 @@ export default function createListComponent({
       return style;
     };
 
-    _getItemStyleCache: (_: any) => ItemStyleCache;
-    _getItemStyleCache = memoizeOne((_: any) => ({}));
+    _getItemStyleCache: (_: any, __: any) => ItemStyleCache;
+    _getItemStyleCache = memoizeOne((_: any, __: any) => ({}));
 
     _getRangeToRender(): [number, number, number, number] {
       const { itemCount, overscanCount } = this.props;
@@ -528,7 +529,7 @@ export default function createListComponent({
       this.setState({ isScrolling: false }, () => {
         // Clear style cache after state update has been committed.
         // This way we don't break pure sCU for items that don't use isScrolling param.
-        this._getItemStyleCache(-1);
+        this._getItemStyleCache(-1, null);
       });
     };
   };

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -413,7 +413,7 @@ export default function createListComponent({
 
     _getRangeToRender(): [number, number, number, number] {
       const { itemCount, overscanCount } = this.props;
-      const { scrollDirection, scrollOffset } = this.state;
+      const { isScrolling, scrollDirection, scrollOffset } = this.state;
 
       if (itemCount === 0) {
         return [0, 0, 0, 0];
@@ -434,9 +434,13 @@ export default function createListComponent({
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
-        scrollDirection === 'backward' ? Math.max(1, overscanCount) : 1;
+        !isScrolling || scrollDirection === 'backward'
+          ? Math.max(1, overscanCount)
+          : 1;
       const overscanForward =
-        scrollDirection === 'forward' ? Math.max(1, overscanCount) : 1;
+        !isScrolling || scrollDirection === 'forward'
+          ? Math.max(1, overscanCount)
+          : 1;
 
       return [
         Math.max(0, startIndex - overscanBackward),

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,6 +2,9 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
+import { cancelTimeout, requestTimeout } from './timer';
+
+import type { TimeoutID } from './timer';
 
 export type ScrollToAlign = 'auto' | 'center' | 'start' | 'end';
 
@@ -217,7 +220,7 @@ export default function createListComponent({
 
     componentWillUnmount() {
       if (this._resetIsScrollingTimeoutId !== null) {
-        clearTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId);
       }
     }
 
@@ -508,10 +511,10 @@ export default function createListComponent({
 
     _resetIsScrollingDebounced = () => {
       if (this._resetIsScrollingTimeoutId !== null) {
-        clearTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId);
       }
 
-      this._resetIsScrollingTimeoutId = setTimeout(
+      this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
         IS_SCROLLING_DEBOUNCE_INTERVAL
       );

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -43,7 +43,8 @@ export type Props<T> = {|
   height: number | string,
   initialScrollOffset?: number,
   innerRef?: any,
-  innerTagName?: string,
+  innerElementType?: React$ElementType,
+  innerTagName?: string, // deprecated
   itemCount: number,
   itemData: T,
   itemKey?: (index: number, data: T) => any,
@@ -51,7 +52,8 @@ export type Props<T> = {|
   onItemsRendered?: onItemsRenderedCallback,
   onScroll?: onScrollCallback,
   outerRef?: any,
-  outerTagName?: string,
+  outerElementType?: React$ElementType,
+  outerTagName?: string, // deprecated
   overscanCount: number,
   style?: Object,
   useIsScrolling: boolean,
@@ -129,9 +131,7 @@ export default function createListComponent({
 
     static defaultProps = {
       direction: 'vertical',
-      innerTagName: 'div',
       itemData: undefined,
-      outerTagName: 'div',
       overscanCount: 2,
       useIsScrolling: false,
     };
@@ -231,10 +231,12 @@ export default function createListComponent({
         direction,
         height,
         innerRef,
+        innerElementType,
         innerTagName,
         itemCount,
         itemData,
         itemKey = defaultItemKey,
+        outerElementType,
         outerTagName,
         style,
         useIsScrolling,
@@ -272,7 +274,7 @@ export default function createListComponent({
       );
 
       return createElement(
-        ((outerTagName: any): string),
+        outerElementType || outerTagName || 'div',
         {
           className,
           onScroll,
@@ -287,7 +289,7 @@ export default function createListComponent({
             ...style,
           },
         },
-        createElement(((innerTagName: any): string), {
+        createElement(innerElementType || innerTagName || 'div', {
           children: items,
           ref: innerRef,
           style: {
@@ -542,9 +544,18 @@ const validateSharedProps = ({
   children,
   direction,
   height,
+  innerTagName,
+  outerTagName,
   width,
 }: Props<any>): void => {
   if (process.env.NODE_ENV !== 'production') {
+    if (innerTagName != null || outerTagName != null) {
+      console.warn(
+        'The innerTagName and outerTagName props have been deprecated. ' +
+          'Please use the innerElementType and outerElementType props instead.'
+      );
+    }
+
     if (direction !== 'horizontal' && direction !== 'vertical') {
       throw Error(
         'An invalid "direction" prop has been specified. ' +

--- a/src/timer.js
+++ b/src/timer.js
@@ -1,0 +1,37 @@
+// @flow
+
+// Animation frame based implementation of setTimeout.
+// Inspired by Joe Lambert, https://gist.github.com/joelambert/1002116#file-requesttimeout-js
+
+const hasNativePerformanceNow =
+  typeof performance === 'object' && typeof performance.now === 'function';
+
+const now = hasNativePerformanceNow
+  ? () => performance.now()
+  : () => Date.now();
+
+export type TimeoutID = {|
+  id: AnimationFrameID,
+|};
+
+export function cancelTimeout(timeoutID: TimeoutID) {
+  cancelAnimationFrame(timeoutID.id);
+}
+
+export function requestTimeout(callback: Function, delay: number): TimeoutID {
+  const start = now();
+
+  function tick() {
+    if (now() - start >= delay) {
+      callback.call(null);
+    } else {
+      timeoutID.id = requestAnimationFrame(tick);
+    }
+  }
+
+  const timeoutID: TimeoutID = {
+    id: requestAnimationFrame(tick),
+  };
+
+  return timeoutID;
+}

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -223,8 +223,8 @@ const PROPS = [
     description: (
       <Fragment>
         <p>
-          The number of items (rows and columns) to render outside of the
-          visible area. This property can be important for two reasons:
+          The number of columns to render outside of the visible area. This
+          property can be important for two reasons:
         </p>
         <ul>
           <li>
@@ -242,7 +242,47 @@ const PROPS = [
         </p>
       </Fragment>
     ),
+    name: 'overscanColumnsCount',
+    type: 'number',
+  },
+  {
+    description: (
+      <Fragment>
+        <p>
+          <strong>This property has been deprecated.</strong> Please use the{' '}
+          <code>overscanColumnsCount</code> and <code>overscanRowsCount</code>{' '}
+          properties instead.
+        </p>
+      </Fragment>
+    ),
     name: 'overscanCount',
+    type: 'number',
+  },
+  {
+    defaultValue: 1,
+    description: (
+      <Fragment>
+        <p>
+          The number of rows to render outside of the visible area. This
+          property can be important for two reasons:
+        </p>
+        <ul>
+          <li>
+            Overscanning by one row or column allows the tab key to focus on the
+            next (not yet visible) item.
+          </li>
+          <li>
+            Overscanning slightly can reduce or prevent a flash of empty space
+            when a user first starts scrolling.
+          </li>
+        </ul>
+        <p>
+          Note that overscanning too much can negatively impact performance. By
+          default, grid overscans by one item.
+        </p>
+      </Fragment>
+    ),
+    name: 'overscanRowsCount',
     type: 'number',
   },
   {

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -116,6 +116,16 @@ const PROPS = [
         the default ("div") should be used.
       </p>
     ),
+    name: 'innerElementType',
+    type: 'React$ElementType',
+  },
+  {
+    description: (
+      <p>
+        <strong>This property has been deprecated.</strong> Please use the{' '}
+        <code>innerElementType</code> prop instead.
+      </p>
+    ),
     name: 'innerTagName',
     type: 'string',
   },
@@ -213,6 +223,16 @@ const PROPS = [
         Tag name passed to <code>document.createElement</code> to create the
         outer container element. This is an advanced property; in most cases,
         the default ("div") should be used.
+      </p>
+    ),
+    name: 'outerElementType',
+    type: 'React$ElementType',
+  },
+  {
+    description: (
+      <p>
+        <strong>This property has been deprecated.</strong> Please use the{' '}
+        <code>outerElementType</code> prop instead.
       </p>
     ),
     name: 'outerTagName',

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -122,8 +122,10 @@ const PROPS = [
   {
     description: (
       <p>
-        <strong>This property has been deprecated.</strong> Please use the{' '}
-        <code>innerElementType</code> prop instead.
+        <strong className={styles.DeprecatedProp}>
+          This property has been deprecated.
+        </strong>{' '}
+        Please use the <code>innerElementType</code> prop instead.
       </p>
     ),
     name: 'innerTagName',
@@ -231,8 +233,10 @@ const PROPS = [
   {
     description: (
       <p>
-        <strong>This property has been deprecated.</strong> Please use the{' '}
-        <code>outerElementType</code> prop instead.
+        <strong className={styles.DeprecatedProp}>
+          This property has been deprecated.
+        </strong>{' '}
+        Please use the <code>outerElementType</code> prop instead.
       </p>
     ),
     name: 'outerTagName',
@@ -267,13 +271,13 @@ const PROPS = [
   },
   {
     description: (
-      <Fragment>
-        <p>
-          <strong>This property has been deprecated.</strong> Please use the{' '}
-          <code>overscanColumnsCount</code> and <code>overscanRowsCount</code>{' '}
-          properties instead.
-        </p>
-      </Fragment>
+      <p>
+        <strong className={styles.DeprecatedProp}>
+          This property has been deprecated.
+        </strong>{' '}
+        Please use the <code>overscanColumnsCount</code> and{' '}
+        <code>overscanRowsCount</code> properties instead.
+      </p>
     ),
     name: 'overscanCount',
     type: 'number',

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -131,8 +131,10 @@ const PROPS = [
   {
     description: (
       <p>
-        <strong>This property has been deprecated.</strong> Please use the{' '}
-        <code>innerElementType</code> prop instead.
+        <strong className={styles.DeprecatedProp}>
+          This property has been deprecated.
+        </strong>{' '}
+        Please use the <code>innerElementType</code> prop instead.
       </p>
     ),
     name: 'innerTagName',
@@ -262,8 +264,10 @@ const PROPS = [
   {
     description: (
       <p>
-        <strong>This property has been deprecated.</strong> Please use the{' '}
-        <code>outerElementType</code> prop instead.
+        <strong className={styles.DeprecatedProp}>
+          This property has been deprecated.
+        </strong>{' '}
+        Please use the <code>outerElementType</code> prop instead.
       </p>
     ),
     name: 'outerTagName',

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -125,6 +125,16 @@ const PROPS = [
         the default ("div") should be used.
       </p>
     ),
+    name: 'innerElementType',
+    type: 'React$ElementType',
+  },
+  {
+    description: (
+      <p>
+        <strong>This property has been deprecated.</strong> Please use the{' '}
+        <code>innerElementType</code> prop instead.
+      </p>
+    ),
     name: 'innerTagName',
     type: 'string',
   },
@@ -244,6 +254,16 @@ const PROPS = [
         Tag name passed to <code>document.createElement</code> to create the
         outer container element. This is an advanced property; in most cases,
         the default ("div") should be used.
+      </p>
+    ),
+    name: 'outerElementType',
+    type: 'React$ElementType',
+  },
+  {
+    description: (
+      <p>
+        <strong>This property has been deprecated.</strong> Please use the{' '}
+        <code>outerElementType</code> prop instead.
       </p>
     ),
     name: 'outerTagName',

--- a/website/src/routes/api/shared.module.css
+++ b/website/src/routes/api/shared.module.css
@@ -4,3 +4,7 @@
   border-radius: 0.25rem;
   background: #263238; /* Codemirror theme */
 }
+
+.DeprecatedProp {
+  color: #ec5f67; /* Codemirror theme */
+}


### PR DESCRIPTION
Resolves #106, #111

* List and Grid components now "overscan" (pre-render) in both directions when scrolling is not active. When scrolling is in progress, cells are only pre-rendered in the direction being scrolled. This change has been made in an effort to reduce visible flicker when scrolling starts without adding additional overhead during scroll (which is the most performance sensitive time).
* Grid components now support separate `overscanColumnsCount` and `overscanRowsCount` props. Legacy `overscanCount` prop will continue to work, but with a deprecation warning in DEV mode.
* Replaced `setTimeout` with `requestAnimationFrame` based timer, to avoid starvation issue for `isScrolling` reset.
* Renamed List and Grid `innerTagName` and `outerTagName` props to `innerElementType` and `outerElementType` to formalize support for attaching arbitrary props (e.g. test ids) to List and Grid inner and outer DOM elements. Legacy `innerTagName` and `outerTagName` props will continue to work, but with a deprecation warning in DEV mode.
* List re-renders items if `direction` prop changes.