### PR TITLE
Recover containerStyle feature from react-virtualized

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -54,6 +54,7 @@ export type Props<T> = {|
   initialScrollTop?: number,
   innerRef?: any,
   innerElementType?: React$ElementType,
+  innerStyle?: Object,
   innerTagName?: string, // deprecated
   itemData: T,
   itemKey?: (params: {|
@@ -288,6 +289,7 @@ export default function createGridComponent({
         height,
         innerRef,
         innerElementType,
+        innerStyle,
         innerTagName,
         itemData,
         itemKey = defaultItemKey,
@@ -366,6 +368,7 @@ export default function createGridComponent({
             height: estimatedTotalHeight,
             pointerEvents: isScrolling ? 'none' : '',
             width: estimatedTotalWidth,
+            ...innerStyle,
           },
         })
       );

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -44,6 +44,7 @@ export type Props<T> = {|
   initialScrollOffset?: number,
   innerRef?: any,
   innerElementType?: React$ElementType,
+  innerStyle?: Object,
   innerTagName?: string, // deprecated
   itemCount: number,
   itemData: T,
@@ -232,6 +233,7 @@ export default function createListComponent({
         height,
         innerRef,
         innerElementType,
+        innerStyle,
         innerTagName,
         itemCount,
         itemData,
@@ -296,6 +298,7 @@ export default function createListComponent({
             height: direction === 'horizontal' ? '100%' : estimatedTotalSize,
             pointerEvents: isScrolling ? 'none' : '',
             width: direction === 'horizontal' ? estimatedTotalSize : '100%',
+            ...innerStyle,
           },
         })
       );


### PR DESCRIPTION
Add `innerStyle` prop  to extend inner element style, just like the outer element.

```javascript
        createElement(innerElementType || innerTagName || 'div', {
          children: items,
          ref: innerRef,
          style: {
            height: direction === 'horizontal' ? '100%' : estimatedTotalSize,
            pointerEvents: isScrolling ? 'none' : '',
            width: direction === 'horizontal' ? estimatedTotalSize : '100%',
            ...innerStyle, //the new prop.
          },
```
