### PR TITLE
Upgrade memoize-one

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "memoize-one": "^3.1.1"
+    "memoize-one": "^5.0.0"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "memoize-one": "^5.0.0"
+    "memoize-one": ">=3.1.1 <6"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -250,8 +250,10 @@ export default function createGridComponent({
       // The scrollbar size should be considered when scrolling an item into view,
       // to ensure it's fully visible.
       // But we only need to account for its size when it's actually visible.
-      const horizontalScrollbarSize = estimatedTotalWidth > width ? scrollbarSize : 0;
-      const verticalScrollbarSize = estimatedTotalHeight > height ? scrollbarSize : 0;
+      const horizontalScrollbarSize =
+        estimatedTotalWidth > width ? scrollbarSize : 0;
+      const verticalScrollbarSize =
+        estimatedTotalHeight > height ? scrollbarSize : 0;
 
       this.scrollTo({
         scrollLeft: getOffsetForColumnAndAlignment(

--- a/website/sandboxes/memoized-list-items/package.json
+++ b/website/sandboxes/memoized-list-items/package.json
@@ -2,7 +2,7 @@
   "description": "Demo of react-window with advanced memoization techniques",
   "main": "src/index.js",
   "dependencies": {
-    "memoize-one": "^4",
+    "memoize-one": "^5",
     "react": "^16.6",
     "react-dom": "^16.6",
     "react-window": "^1"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6161,9 +6161,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-3.1.1.tgz#ef609811e3bc28970eac2884eece64d167830d17"
+memoize-one@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
+  integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,9 +5596,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-3.1.1.tgz#ef609811e3bc28970eac2884eece64d167830d17"
+memoize-one@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
+  integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,7 +5596,7 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-memoize-one@^5.0.0:
+"memoize-one@>=3.1.1 <6":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
   integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==


### PR DESCRIPTION
Upgrades `memoize-one` to the latest version `^5.0.0`.

Breaking changes between 3.1.1 and 5.0.0 do not affect `react-window`.

- 4.0 changed the bundled output, which was only technically a breaking change
- [5.0 changed the API for the optional comparer function](https://github.com/alexreardon/memoize-one/releases/tag/v5.0.0), which is not used in `react-window`