### PR TITLE
Reduce bundle size (WIP)

### DIFF
--- a/mangle.json
+++ b/mangle.json
@@ -1,0 +1,19 @@
+{
+  "_callOnItemsRendered": "_a",
+  "_callOnScroll": "_b",
+  "_callPropsCallbacks": "_c",
+  "_getHorizontalRangeToRender": "_d",
+  "_getItemStyle": "_e",
+  "_getItemStyleCache": "_f",
+  "_getRangeToRender": "_g",
+  "_getVerticalRangeToRender": "_h",
+  "_instanceProps": "_i",
+  "_onScroll": "_j",
+  "_onScrollHorizontal": "_k",
+  "_onScrollVertical": "_l",
+  "_outerRef": "_m",
+  "_outerRefSetter": "_n",
+  "_resetIsScrolling": "_o",
+  "_resetIsScrollingDebounced": "_p",
+  "_resetIsScrollingTimeoutId": "_q"
+}

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "rollup": "^1.4.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.1",
-    "rollup-plugin-node-resolve": "^4.0.1"
+    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-postprocess": "^1.0.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,14 @@
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
+import postprocess from 'rollup-plugin-postprocess';
+import { readFileSync } from 'fs';
 
 import pkg from './package.json';
+
+// This file controls protected/private property mangling so that minified builds have consistent property names.
+const mangle = JSON.parse(readFileSync('./mangle.json', 'utf8'));
+const postprocessConfig = Object.entries(mangle);
 
 const input = './src/index.js';
 
@@ -23,6 +29,7 @@ export default [
       }),
       nodeResolve(),
       commonjs(),
+      postprocess(postprocessConfig),
     ],
   },
 
@@ -40,6 +47,7 @@ export default [
       }),
       nodeResolve(),
       commonjs(),
+      postprocess(postprocessConfig),
     ],
   },
 ];

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -171,8 +171,8 @@ export default function createGridComponent({
 |}) {
   return class Grid<T> extends PureComponent<Props<T>, State> {
     _instanceProps: any = initInstanceProps(this.props, this);
-    _resetIsScrollingTimeoutId: TimeoutID | null = null;
     _outerRef: ?HTMLDivElement;
+    _resetIsScrollingTimeoutId: TimeoutID | null = null;
 
     static defaultProps = {
       direction: 'ltr',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,6 +5552,13 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
+magic-string@^0.22.4:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  integrity sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
+  dependencies:
+    vlq "^0.2.2"
+
 magic-string@^0.25.1:
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
@@ -7396,6 +7403,13 @@ rollup-plugin-node-resolve@^4.0.1:
     is-module "^1.0.0"
     resolve "^1.10.0"
 
+rollup-plugin-postprocess@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-postprocess/-/rollup-plugin-postprocess-1.0.2.tgz#673d31ccbfb121dfa8c836d2f35b8c6f508a8b5f"
+  integrity sha512-teKF5sVgjoQPRF9IV4wTED0Tx6kuoyz4rxkiSG9NweBC28fwXy+sZ0HLDw9GwCwck///08hFGi0RY4jlSdoZTA==
+  dependencies:
+    magic-string "^0.22.4"
+
 rollup-pluginutils@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.1.tgz#760d185ccc237dedc12d7ae48c6bcd127b4892d0"
@@ -8455,6 +8469,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vlq@^0.2.2:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 vm-browserify@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Relates to #157

* 7c51f89: First attempt is an experiment with [rollup-plugin-postprocess](https://github.com/developit/rollup-plugin-postprocess) to minify "private" attributes. This shaved 104 B off of a create-react-app that imported the FixedSizeList component. This is pretty janky though.

Ideally this would use something like terser, but it currently strings the `#__PURE__` annotations, which breaks tree shaking and makes the bundle worse.