### PR TITLE
[WIP] Fix RTL scrolling issues in some browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 .env.test.local
 .env.production.local
 .watchmanconfig
+.idea
 
 package-lock.json
 npm-debug.log*

--- a/src/FixedSizeList.js
+++ b/src/FixedSizeList.js
@@ -23,12 +23,9 @@ const FixedSizeList = createListComponent({
     // TODO Deprecate direction "horizontal"
     const isHorizontal = direction === 'horizontal' || layout === 'horizontal';
     const size = (((isHorizontal ? width : height): any): number);
-    const maxOffset = Math.max(
-      0,
-      Math.min(
-        itemCount * ((itemSize: any): number) - size,
-        index * ((itemSize: any): number)
-      )
+    const maxOffset = Math.min(
+      itemCount * ((itemSize: any): number) - size,
+      index * ((itemSize: any): number)
     );
     const minOffset = Math.max(
       0,
@@ -55,10 +52,10 @@ const FixedSizeList = createListComponent({
   },
 
   getStartIndexForOffset: (
-    { itemCount, itemSize }: Props<any>,
+    { itemCount, itemSize, direction }: Props<any>,
     offset: number
   ): number =>
-    Math.max(
+    Math[direction === 'rtl' ? 'min' : 'max'](
       0,
       Math.min(itemCount - 1, Math.floor(offset / ((itemSize: any): number)))
     ),

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -668,14 +668,23 @@ export default function createGridComponent({
 
         const { direction } = this.props;
 
+        // HACK According to the spec, scrollLeft should be negative for RTL aligned elements.
+        // Chrome does not seem to adhere; its scrolLeft values are positive (measured relative to the left).
+        // See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft
+        let calculatedScrollLeft = scrollLeft;
+        if (direction === 'rtl') {
+          if (scrollLeft < 0) {
+            calculatedScrollLeft = -scrollLeft;
+          } else {
+            calculatedScrollLeft = scrollWidth - clientWidth - scrollLeft;
+          }
+        }
+
         return {
           isScrolling: true,
           horizontalScrollDirection:
             prevState.scrollLeft < scrollLeft ? 'forward' : 'backward',
-          scrollLeft:
-            direction === 'rtl'
-              ? scrollWidth - clientWidth - scrollLeft
-              : scrollLeft,
+          scrollLeft: calculatedScrollLeft,
           scrollTop,
           verticalScrollDirection:
             prevState.scrollTop < scrollTop ? 'forward' : 'backward',

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -307,7 +307,7 @@ export default function createListComponent({
             overflow: 'auto',
             WebkitOverflowScrolling: 'touch',
             willChange: 'transform',
-            direction: direction === 'rtl' ? 'rtl' : 'ltr',
+            direction,
             ...style,
           },
         },
@@ -486,14 +486,23 @@ export default function createListComponent({
 
         const { direction } = this.props;
 
+        // HACK According to the spec, scrollLeft should be negative for RTL aligned elements.
+        // Chrome does not seem to adhere; its scrolLeft values are positive (measured relative to the left).
+        // See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft
+        let scrollOffset = scrollLeft;
+        if (direction === 'rtl') {
+          if (scrollLeft < 0) {
+            scrollOffset = -scrollOffset;
+          } else {
+            scrollOffset = scrollWidth - clientWidth - scrollLeft;
+          }
+        }
+
         return {
           isScrolling: true,
           scrollDirection:
             prevState.scrollOffset < scrollLeft ? 'forward' : 'backward',
-          scrollOffset:
-            direction === 'rtl'
-              ? scrollWidth - clientWidth - scrollLeft
-              : scrollLeft,
+          scrollOffset,
           scrollUpdateWasRequested: false,
         };
       }, this._resetIsScrollingDebounced);

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -490,8 +490,16 @@ export default function createListComponent({
         // Chrome does not seem to adhere; its scrolLeft values are positive (measured relative to the left).
         // See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft
         let scrollOffset = scrollLeft;
+        const isStandardRtl = prevState.scrollLeft < 0;
+        const isBouncing = prevState.isStandardRtl && scrollLeft > 0;
+
+        isBouncing && (scrollOffset = -scrollOffset);
         if (direction === 'rtl') {
-          if (scrollLeft <= 0) {
+          if (
+            scrollLeft < 0 ||
+            ((scrollLeft === 0 && isStandardRtl) ||
+              (prevState.isStandardRtl && !isBouncing))
+          ) {
             scrollOffset = -scrollOffset;
           } else {
             scrollOffset = scrollWidth - clientWidth - scrollLeft;
@@ -502,7 +510,9 @@ export default function createListComponent({
           isScrolling: true,
           scrollDirection:
             prevState.scrollOffset < scrollLeft ? 'forward' : 'backward',
-          scrollOffset,
+          scrollOffset: isBouncing ? prevState.scrollLeft : scrollOffset,
+          scrollLeft,
+          isStandardRtl: isStandardRtl || prevState.isStandardRtl,
           scrollUpdateWasRequested: false,
         };
       }, this._resetIsScrollingDebounced);

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -224,13 +224,18 @@ export default function createListComponent({
     }
 
     componentDidUpdate() {
-      const { direction, layout } = this.props;
+      const { direction, itemCount, itemSize, layout, width } = this.props;
       const { scrollOffset, scrollUpdateWasRequested } = this.state;
 
       if (scrollUpdateWasRequested && this._outerRef !== null) {
         // TODO Deprecate direction "horizontal"
         if (direction === 'horizontal' || layout === 'horizontal') {
-          ((this._outerRef: any): HTMLDivElement).scrollLeft = scrollOffset;
+          const scrollWithDirection =
+            direction === 'rtl'
+              ? itemCount * itemSize - width - scrollOffset
+              : scrollOffset;
+          ((this
+            ._outerRef: any): HTMLDivElement).scrollLeft = scrollWithDirection;
         } else {
           ((this._outerRef: any): HTMLDivElement).scrollTop = scrollOffset;
         }

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -69,6 +69,8 @@ type State = {|
   scrollDirection: ScrollDirection,
   scrollOffset: number,
   scrollUpdateWasRequested: boolean,
+  isStandardRtl: boolean,
+  scrollLeft: number,
 |};
 
 type GetItemOffset = (
@@ -159,6 +161,8 @@ export default function createListComponent({
           ? this.props.initialScrollOffset
           : 0,
       scrollUpdateWasRequested: false,
+      isStandardRtl: false,
+      scrollLeft: 0,
     };
 
     // Always use explicit constructor for React components.


### PR DESCRIPTION
Attempt to fix some RTL scrolling issues in some browsers due to inconsistent RTL support.
Tested in Chrome, Firefox and Safari latest versions.
The fix is ugly as hell but needs to tackle at least tree different cases:
- Non standard Chrome support for RTL overflow metrics.
- Standard support from Firefox.
- Buggy behaviour on Safari bouncing when the scroll reaches the right limit in RTL layout.

#### Pending tasks:
- Testing in Edge.
- Fix scrollToItem and scrollTo methods to work with RTL direction.
- Apply similar fix for Grid component.