### PR TITLE
Avoid crash if WeakSet is not available

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -4,7 +4,6 @@ import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize } from './domHelpers';
-import WeakSet from './weakset';
 
 import type { TimeoutID } from './timer';
 
@@ -133,8 +132,10 @@ const defaultItemKey = ({ columnIndex, data, rowIndex }) =>
 let devWarningsOverscanCount = null;
 let devWarningsTagName = null;
 if (process.env.NODE_ENV !== 'production') {
-  devWarningsOverscanCount = new WeakSet();
-  devWarningsTagName = new WeakSet();
+  if (typeof window.WeakSet !== 'undefined') {
+    devWarningsOverscanCount = new WeakSet();
+    devWarningsTagName = new WeakSet();
+  }
 }
 
 export default function createGridComponent({
@@ -747,8 +748,8 @@ const validateSharedProps = (
 ): void => {
   if (process.env.NODE_ENV !== 'production') {
     if (typeof overscanCount === 'number') {
-      if (!((devWarningsOverscanCount: any): WeakSet<any>).has(instance)) {
-        ((devWarningsOverscanCount: any): WeakSet<any>).add(instance);
+      if (devWarningsOverscanCount && !devWarningsOverscanCount.has(instance)) {
+        devWarningsOverscanCount.add(instance);
         console.warn(
           'The overscanCount prop has been deprecated. ' +
             'Please use the overscanColumnsCount and overscanRowsCount props instead.'
@@ -757,8 +758,8 @@ const validateSharedProps = (
     }
 
     if (innerTagName != null || outerTagName != null) {
-      if (!((devWarningsTagName: any): WeakSet<any>).has(instance)) {
-        ((devWarningsTagName: any): WeakSet<any>).add(instance);
+      if (devWarningsTagName && !devWarningsTagName.has(instance)) {
+        devWarningsTagName.add(instance);
         console.warn(
           'The innerTagName and outerTagName props have been deprecated. ' +
             'Please use the innerElementType and outerElementType props instead.'

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -4,6 +4,7 @@ import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize } from './domHelpers';
+import WeakSet from './weakset';
 
 import type { TimeoutID } from './timer';
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -3,6 +3,7 @@
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
+import WeakSet from './weakset';
 
 import type { TimeoutID } from './timer';
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -3,7 +3,6 @@
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
-import WeakSet from './weakset';
 
 import type { TimeoutID } from './timer';
 
@@ -113,8 +112,10 @@ const defaultItemKey = (index: number, data: any) => index;
 let devWarningsDirection = null;
 let devWarningsTagName = null;
 if (process.env.NODE_ENV !== 'production') {
-  devWarningsDirection = new WeakSet();
-  devWarningsTagName = new WeakSet();
+  if (typeof window.WeakSet !== 'undefined') {
+    devWarningsDirection = new WeakSet();
+    devWarningsTagName = new WeakSet();
+  }
 }
 
 export default function createListComponent({
@@ -588,8 +589,8 @@ const validateSharedProps = (
 ): void => {
   if (process.env.NODE_ENV !== 'production') {
     if (innerTagName != null || outerTagName != null) {
-      if (!((devWarningsTagName: any): WeakSet<any>).has(instance)) {
-        ((devWarningsTagName: any): WeakSet<any>).add(instance);
+      if (devWarningsTagName && !devWarningsTagName.has(instance)) {
+        devWarningsTagName.add(instance);
         console.warn(
           'The innerTagName and outerTagName props have been deprecated. ' +
             'Please use the innerElementType and outerElementType props instead.'
@@ -603,8 +604,8 @@ const validateSharedProps = (
     switch (direction) {
       case 'horizontal':
       case 'vertical':
-        if (!((devWarningsDirection: any): WeakSet<any>).has(instance)) {
-          ((devWarningsDirection: any): WeakSet<any>).add(instance);
+        if (devWarningsDirection && !devWarningsDirection.has(instance)) {
+          devWarningsDirection.add(instance);
           console.warn(
             'The direction prop should be either "ltr" (default) or "rtl". ' +
               'Please use the layout prop to specify "vertical" (default) or "horizontal" orientation.'

--- a/src/weakset.js
+++ b/src/weakset.js
@@ -1,5 +1,0 @@
-// @flow
-
-const WeakSetExport: typeof WeakSet =
-  typeof (WeakSet: any) === 'undefined' ? (Set: any) : (WeakSet: any);
-export default WeakSetExport;

--- a/src/weakset.js
+++ b/src/weakset.js
@@ -1,0 +1,4 @@
+// @flow
+
+const WeaksetExport = typeof WeakSet === 'undefined' ? Set : WeakSet;
+export default WeaksetExport;

--- a/src/weakset.js
+++ b/src/weakset.js
@@ -1,4 +1,5 @@
 // @flow
 
-const WeaksetExport = typeof WeakSet === 'undefined' ? Set : WeakSet;
-export default WeaksetExport;
+const WeakSetExport: typeof WeakSet =
+  typeof (WeakSet: any) === 'undefined' ? (Set: any) : (WeakSet: any);
+export default WeakSetExport;


### PR DESCRIPTION
`WeakSet` is not available in IE11, so using `react-window` in development mode causes a runtime error.

This simply falls back to `Set` if `WeakSet` is not available. This could have memory implications since `Set` will hold onto the references indefinitely, but that only affects the one browser and only in development mode. It's also a much smaller impact on bundle size vs., say, a polyfill.