### PR TITLE
Make rowIndex and columnIndex optional

### DIFF
--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -475,6 +475,10 @@ describe('FixedSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 2, rowIndex: 2, align: 'auto' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'auto' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'auto' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -497,6 +501,10 @@ describe('FixedSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 99, rowIndex: 99, align: 'start' });
+      // Scroll up to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'start' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'start' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -519,6 +527,10 @@ describe('FixedSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 1, rowIndex: 1, align: 'end' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'end' });
+      // Scroll right to column 9, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 9, align: 'end' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -547,6 +559,10 @@ describe('FixedSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 99, rowIndex: 99, align: 'center' });
+      // Scroll up to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'center' });
+      // Scroll left to column 3, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 3, align: 'center' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 

--- a/src/__tests__/VariableSizeGrid.js
+++ b/src/__tests__/VariableSizeGrid.js
@@ -190,6 +190,10 @@ describe('VariableSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 2, rowIndex: 2, align: 'auto' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'auto' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'auto' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -212,6 +216,10 @@ describe('VariableSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 9, rowIndex: 19, align: 'start' });
+      // Scroll up to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'start' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'start' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -234,6 +242,10 @@ describe('VariableSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 1, rowIndex: 1, align: 'end' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'end' });
+      // Scroll right to column 9, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 9, align: 'end' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -262,6 +274,10 @@ describe('VariableSizeGrid', () => {
       rendered
         .getInstance()
         .scrollToItem({ columnIndex: 9, rowIndex: 19, align: 'center' });
+      // Scroll up to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'center' });
+      // Scroll left to column 3, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 3, align: 'center' });
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 

--- a/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
@@ -311,6 +311,30 @@ Array [
       "visibleRowStopIndex": 6,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 1,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 6,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 2,
+      "visibleColumnStopIndex": 4,
+      "visibleRowStartIndex": 7,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 3,
+      "overscanRowStartIndex": 6,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 2,
+      "visibleRowStartIndex": 7,
+      "visibleRowStopIndex": 11,
+    },
+  ],
 ]
 `;
 
@@ -376,6 +400,30 @@ Array [
       "visibleRowStopIndex": 99,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 97,
+      "overscanColumnStopIndex": 99,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 98,
+      "visibleColumnStopIndex": 99,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 1,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 2,
+      "visibleColumnStopIndex": 4,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 12,
+    },
+  ],
 ]
 `;
 
@@ -429,6 +477,30 @@ Array [
       "visibleRowStopIndex": 4,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 3,
+      "overscanRowStartIndex": 6,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 2,
+      "visibleRowStartIndex": 7,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 7,
+      "overscanColumnStopIndex": 11,
+      "overscanRowStartIndex": 6,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 8,
+      "visibleColumnStopIndex": 10,
+      "visibleRowStartIndex": 7,
+      "visibleRowStopIndex": 11,
+    },
+  ],
 ]
 `;
 
@@ -480,6 +552,30 @@ Array [
       "visibleColumnStopIndex": 99,
       "visibleRowStartIndex": 96,
       "visibleRowStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 97,
+      "overscanColumnStopIndex": 99,
+      "overscanRowStartIndex": 9,
+      "overscanRowStopIndex": 15,
+      "visibleColumnStartIndex": 98,
+      "visibleColumnStopIndex": 99,
+      "visibleRowStartIndex": 10,
+      "visibleRowStopIndex": 14,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 3,
+      "overscanRowStartIndex": 9,
+      "overscanRowStopIndex": 15,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 2,
+      "visibleRowStartIndex": 10,
+      "visibleRowStopIndex": 14,
     },
   ],
 ]

--- a/src/__tests__/__snapshots__/VariableSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/VariableSizeGrid.js.snap
@@ -26,6 +26,30 @@ Array [
       "visibleRowStopIndex": 5,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 1,
+      "overscanColumnStopIndex": 6,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 11,
+      "visibleColumnStartIndex": 2,
+      "visibleColumnStopIndex": 5,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 10,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 11,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 10,
+    },
+  ],
 ]
 `;
 
@@ -91,6 +115,30 @@ Array [
       "visibleRowStopIndex": 19,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 5,
+      "overscanColumnStopIndex": 9,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 6,
+      "visibleColumnStopIndex": 9,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 6,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 5,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
 ]
 `;
 
@@ -144,6 +192,30 @@ Array [
       "visibleRowStopIndex": 3,
     },
   ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 11,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 10,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 5,
+      "overscanColumnStopIndex": 9,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 11,
+      "visibleColumnStartIndex": 6,
+      "visibleColumnStopIndex": 9,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 10,
+    },
+  ],
 ]
 `;
 
@@ -195,6 +267,30 @@ Array [
       "visibleColumnStopIndex": 9,
       "visibleRowStartIndex": 17,
       "visibleRowStopIndex": 19,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 5,
+      "overscanColumnStopIndex": 9,
+      "overscanRowStartIndex": 9,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 6,
+      "visibleColumnStopIndex": 9,
+      "visibleRowStartIndex": 10,
+      "visibleRowStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 9,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 10,
+      "visibleRowStopIndex": 12,
     },
   ],
 ]

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -247,8 +247,8 @@ export default function createGridComponent({
       rowIndex,
     }: {
       align: ScrollToAlign,
-      columnIndex: number,
-      rowIndex: number,
+      columnIndex?: number,
+      rowIndex?: number,
     }): void {
       const { height, width } = this.props;
       const { scrollLeft, scrollTop } = this.state;
@@ -272,22 +272,28 @@ export default function createGridComponent({
         estimatedTotalHeight > height ? scrollbarSize : 0;
 
       this.scrollTo({
-        scrollLeft: getOffsetForColumnAndAlignment(
-          this.props,
-          columnIndex,
-          align,
-          scrollLeft,
-          this._instanceProps,
-          verticalScrollbarSize
-        ),
-        scrollTop: getOffsetForRowAndAlignment(
-          this.props,
-          rowIndex,
-          align,
-          scrollTop,
-          this._instanceProps,
-          horizontalScrollbarSize
-        ),
+        scrollLeft:
+          columnIndex !== undefined
+            ? getOffsetForColumnAndAlignment(
+                this.props,
+                columnIndex,
+                align,
+                scrollLeft,
+                this._instanceProps,
+                verticalScrollbarSize
+              )
+            : scrollLeft,
+        scrollTop:
+          rowIndex !== undefined
+            ? getOffsetForRowAndAlignment(
+                this.props,
+                rowIndex,
+                align,
+                scrollTop,
+                this._instanceProps,
+                horizontalScrollbarSize
+              )
+            : scrollTop,
       });
     }
 

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -206,7 +206,7 @@ const PROPS = [
       <Fragment>
         <p>Called when the range of items rendered by the grid changes.</p>
         <p>
-          This callback will only be called when item indices change. It will
+          This callback will only be called when item indices change. It will
           not be called if items are re-rendered for other reasons (e.g. a
           change in <code>isScrolling</code> or <code>data</code> params).
         </p>
@@ -409,19 +409,31 @@ const METHODS = [
         <p>
           By default, the Grid will scroll as little as possible to ensure the
           item is visible. You can control the alignment of the item though by
-          specifying a second alignment parameter. Acceptable values are:
+          specifying an <code>align</code> property. Acceptable values are:
         </p>
         <ul>
           <li>
-            auto (default) - Scroll as little as possible to ensure the item is
-            visible. (If the item is already visible, it won't scroll at all.)
+            <code>auto</code> (default) - Scroll as little as possible to ensure
+            the item is visible. (If the item is already visible, it won't
+            scroll at all.)
           </li>
-          <li>center - Center align the item within the grid.</li>
           <li>
-            end - Align the item to the bottom, right hand side of the grid.
+            <code>center</code> - Center align the item within the grid.
           </li>
-          <li>start - Align the item to the top, left hand of the grid.</li>
+          <li>
+            <code>end</code> - Align the item to the bottom, right hand side of
+            the grid.
+          </li>
+          <li>
+            <code>start</code> - Align the item to the top, left hand of the
+            grid.
+          </li>
         </ul>
+        <p>
+          If either <code>columnIndex</code> or <code>rowIndex</code> are
+          omitted, <code>scrollLeft</code> or <code>scrollTop</code> will be
+          unchanged (respectively).
+        </p>
         <p>
           <Link to="/examples/list/scroll-to-item">
             See here for an example of this API.
@@ -430,6 +442,6 @@ const METHODS = [
       </Fragment>
     ),
     signature:
-      'scrollToItem({align: string = "auto", columnIndex: number, rowIndex: number }): void',
+      'scrollToItem({align: string = "auto", columnIndex?: number, rowIndex?: number }): void',
   },
 ];


### PR DESCRIPTION
Closes #173.

Update `scrollToItem` to make `rowIndex` and `columnIndex` optional. If unspecified (or invalid, e.g., negative value), the current value for `scrollTop` or `scrollLeft` will be used.

- Updated tests
- Updated documentation