### PR TITLE
fix for codemirror loader test regexp not catering for windows paths

### DIFF
--- a/website/config/webpack.config.dev.js
+++ b/website/config/webpack.config.dev.js
@@ -181,7 +181,7 @@ module.exports = {
 
           // Custom CodeMirror loader for syntax highlighting
           {
-            test: /code\/[^/]+$/,
+            test: /code[/\\\\]/,
             loader: require.resolve('../webpack/codemirror-loader'),
           },
 

--- a/website/config/webpack.config.prod.js
+++ b/website/config/webpack.config.prod.js
@@ -211,7 +211,7 @@ module.exports = {
 
           // Custom CodeMirror loader for syntax highlighting
           {
-            test: /code\/[^/]+$/,
+            test: /code[/\\\\]/,
             loader: require.resolve('../webpack/codemirror-loader'),
           },
 


### PR DESCRIPTION
I hope this little fix helps others like me trying to build on windows.
