### PR TITLE
Fix path to LICENSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React components for efficiently rendering large lists and tabular data
 
-[![NPM registry](https://img.shields.io/npm/v/react-window.svg?style=for-the-badge)](https://yarnpkg.com/en/package/react-window) [![Travis](https://img.shields.io/badge/ci-travis-green.svg?style=for-the-badge)](https://travis-ci.org/bvaughn/react-window) [![NPM license](https://img.shields.io/badge/license-mit-red.svg?style=for-the-badge)](LICENSE)
+[![NPM registry](https://img.shields.io/npm/v/react-window.svg?style=for-the-badge)](https://yarnpkg.com/en/package/react-window) [![Travis](https://img.shields.io/badge/ci-travis-green.svg?style=for-the-badge)](https://travis-ci.org/bvaughn/react-window) [![NPM license](https://img.shields.io/badge/license-mit-red.svg?style=for-the-badge)](LICENSE.md)
 
 ## Install
 


### PR DESCRIPTION
I found a broken link to LICENSE without extension:

[Current state](https://user-images.githubusercontent.com/1788245/54567671-af5da880-49e5-11e9-95eb-300dcd7bf536.png)
[Fixed state](https://user-images.githubusercontent.com/1788245/54567707-cd2b0d80-49e5-11e9-93b6-1915c5cded57.png)