### PR TITLE
Add persistedIndexes prop to createListComponent

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -61,6 +61,7 @@ export type Props<T> = {|
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
+  persistedIndexes?: number[],
 |};
 
 type State = {|
@@ -261,6 +262,7 @@ export default function createListComponent({
         style,
         useIsScrolling,
         width,
+        persistedIndexes,
       } = this.props;
       const { isScrolling } = this.state;
 
@@ -287,6 +289,21 @@ export default function createListComponent({
             })
           );
         }
+      }
+      if (persistedIndexes) {
+        persistedIndexes.forEach(index => {
+          // @flow-ignore
+          if (!items.find(item => item.key === index))
+            items.push(
+              createElement(children, {
+                data: itemData,
+                key: itemKey(index, itemData),
+                index,
+                isScrolling: useIsScrolling ? isScrolling : undefined,
+                style: this._getItemStyle(index),
+              })
+            );
+        });
       }
 
       // Read this value AFTER items have been created,


### PR DESCRIPTION
Couldn't find a contributing guide so not sure what the policies are here! 😁

This PR attempts to add a prop named "persistIndexes" to createListComponent. Any indexes specified will be rendered (persisted) even when they are out of the current window. It will enable the popular use-case "sticky header" as asked for in #55 with a relatively small change.

Example https://codesandbox.io/s/kmov2m4903?fontsize=14&view=preview,

```JSX
import { FixedSizeList as List } from 'react-window';
 
const Row = ({ index, style }) => (
  <div style={style} className={index === 0 ? "sticky" : null}>Row {index}</div>
);
 
const Example = () => (
  <List
    height={150}
    itemCount={1000}
    itemSize={35}
    width={300}
    // array of indexes to persist regardless of scroll position
    persistedIndexes={[0]}
  >
    {Row}
  </List>
);
```

```css 
.sticky {
  position: sticky !important;
  top: 0px;
}
```

This might very well be a simple and extremely naive implementation... 😊