### PR TITLE
Allow paddingTop and paddingBottom in Lists

### DIFF
--- a/src/FixedSizeList.js
+++ b/src/FixedSizeList.js
@@ -5,8 +5,8 @@ import createListComponent from './createListComponent';
 import type { Props, ScrollToAlign } from './createListComponent';
 
 const FixedSizeList = createListComponent({
-  getItemOffset: ({ itemSize, size }: Props<any>, index: number): number =>
-    index * ((itemSize: any): number),
+  getItemOffset: ({ itemSize, paddingTop, size }: Props<any>, index: number): number =>
+    paddingTop + index * ((itemSize: any): number),
 
   getItemSize: ({ itemSize, size }: Props<any>, index: number): number =>
     ((itemSize: any): number),
@@ -15,7 +15,7 @@ const FixedSizeList = createListComponent({
     ((itemSize: any): number) * itemCount,
 
   getOffsetForIndexAndAlignment: (
-    { direction, height, itemCount, itemSize, layout, width }: Props<any>,
+    { direction, height, itemCount, itemSize, layout, paddingTop, width }: Props<any>,
     index: number,
     align: ScrollToAlign,
     scrollOffset: number
@@ -23,14 +23,14 @@ const FixedSizeList = createListComponent({
     // TODO Deprecate direction "horizontal"
     const isHorizontal = direction === 'horizontal' || layout === 'horizontal';
     const size = (((isHorizontal ? width : height): any): number);
-    const maxOffset = Math.max(
+    const maxOffset = paddingTop + Math.max(
       0,
       Math.min(
         itemCount * ((itemSize: any): number) - size,
         index * ((itemSize: any): number)
       )
     );
-    const minOffset = Math.max(
+    const minOffset = paddingTop + Math.max(
       0,
       index * ((itemSize: any): number) - size + ((itemSize: any): number)
     );

--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -28,7 +28,7 @@ const getItemMetadata = (
   index: number,
   instanceProps: InstanceProps
 ): ItemMetadata => {
-  const { itemSize } = ((props: any): VariableSizeProps);
+  const { itemSize, paddingTop } = ((props: any): VariableSizeProps);
   const { itemMetadataMap, lastMeasuredIndex } = instanceProps;
 
   if (index > lastMeasuredIndex) {
@@ -52,7 +52,7 @@ const getItemMetadata = (
     instanceProps.lastMeasuredIndex = index;
   }
 
-  return itemMetadataMap[index];
+  return index > 0 ? itemMetadataMap[index] : paddingTop + itemMetadataMap[index];
 };
 
 const findNearestItem = (

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -58,6 +58,8 @@ export type Props<T> = {|
   outerElementType?: React$ElementType,
   outerTagName?: string, // deprecated
   overscanCount: number,
+  paddingBottom: number,
+  paddingTop: number,
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
@@ -149,6 +151,8 @@ export default function createListComponent({
       itemData: undefined,
       layout: 'vertical',
       overscanCount: 2,
+      paddingTop: 0,
+      paddingBottom: 0,
       useIsScrolling: false,
     };
 
@@ -258,6 +262,8 @@ export default function createListComponent({
         layout,
         outerElementType,
         outerTagName,
+        paddingBottom,
+        paddingTop,
         style,
         useIsScrolling,
         width,
@@ -294,7 +300,7 @@ export default function createListComponent({
       const estimatedTotalSize = getEstimatedTotalSize(
         this.props,
         this._instanceProps
-      );
+      ) + paddingBottom + paddingTop;
 
       return createElement(
         outerElementType || outerTagName || 'div',


### PR DESCRIPTION
Hi,

I know that in #74, @bvaughn said the way to add `paddingTop` and `paddingBottom` to a list would be through using a `VariableSizeList` and making the first and last elements pushers.

That seemed to work alright for a `Tree` component we implemented using `react-window` (which we'll hopefully open source at some point :)) but it was actually broken underneath.

The problem we faced was that in order to get the right size for the pushers we needed to increase the lists' size by two and then use an `itemSize` function that would determine the height. However, because that function caches the sizes aggressively, we were forced to put a `key` into the `List` to force it to re-render (couldn't find any other way) and recalculate the heights for each element.

The problem with that approach is that the focus is lost and the tree scrolls back to the top as soon as you select something in the middle.

If we don't use the `key`, then when the list grows in size, we have a gap in what should've been the last element but it isn't anymore.

I dug a bit on what it would mean to add the paddings to the list and unless something it didn't add all that much complexity to the code. It would be good if someone could sound the `scrollTo` part though.

What do you think?
Thanks!
Darío

Edit: I've released it here in the meantime https://www.npmjs.com/package/@viewstools/react-window-padded-lists so we can use it internally