### PR TITLE
New scroll align mode: 'smart'

### DIFF
--- a/src/FixedSizeGrid.js
+++ b/src/FixedSizeGrid.js
@@ -46,6 +46,14 @@ const FixedSizeGrid = createGridComponent({
         ((columnWidth: any): number)
     );
 
+    if (align === 'smart') {
+      if (scrollLeft >= minOffset - width && scrollLeft <= maxOffset + width) {
+        align = 'auto';
+      } else {
+        align = 'center';
+      }
+    }
+
     switch (align) {
       case 'start':
         return maxOffset;
@@ -87,6 +95,14 @@ const FixedSizeGrid = createGridComponent({
         scrollbarSize +
         ((rowHeight: any): number)
     );
+
+    if (align === 'smart') {
+      if (scrollTop >= minOffset - height && scrollTop <= maxOffset + height) {
+        align = 'auto';
+      } else {
+        align = 'center';
+      }
+    }
 
     switch (align) {
       case 'start':

--- a/src/FixedSizeList.js
+++ b/src/FixedSizeList.js
@@ -35,6 +35,17 @@ const FixedSizeList = createListComponent({
       index * ((itemSize: any): number) - size + ((itemSize: any): number)
     );
 
+    if (align === 'smart') {
+      if (
+        scrollOffset >= minOffset - size &&
+        scrollOffset <= maxOffset + size
+      ) {
+        align = 'auto';
+      } else {
+        align = 'center';
+      }
+    }
+
     switch (align) {
       case 'start':
         return maxOffset;

--- a/src/VariableSizeGrid.js
+++ b/src/VariableSizeGrid.js
@@ -255,6 +255,14 @@ const getOffsetForIndexAndAlignment = (
     itemMetadata.offset - size + scrollbarSize + itemMetadata.size
   );
 
+  if (align === 'smart') {
+    if (scrollOffset >= minOffset - size && scrollOffset <= maxOffset + size) {
+      align = 'auto';
+    } else {
+      align = 'center';
+    }
+  }
+
   switch (align) {
     case 'start':
       return maxOffset;

--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -205,6 +205,17 @@ const VariableSizeList = createListComponent({
       itemMetadata.offset - size + itemMetadata.size
     );
 
+    if (align === 'smart') {
+      if (
+        scrollOffset >= minOffset - size &&
+        scrollOffset <= maxOffset + size
+      ) {
+        align = 'auto';
+      } else {
+        align = 'center';
+      }
+    }
+
     switch (align) {
       case 'start':
         return maxOffset;

--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -565,6 +565,41 @@ describe('FixedSizeGrid', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
+    it('should scroll to the correct item for align = "smart"', () => {
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeGrid {...defaultProps} />
+      );
+
+      // Scroll down enough to show item 10 at the center.
+      // It was further than one screen away, so it gets centered.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 10, rowIndex: 10, align: 'smart' });
+      // No need to scroll again; item 9 is already visible.
+      // Overscan indices will change though, since direction changes.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 9, rowIndex: 9, align: 'smart' });
+      // Scroll up enough to show item 2 as close to the center as we can.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 2, rowIndex: 2, align: 'smart' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'smart' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'smart' });
+
+      // Scrolling within a distance of a single screen from viewport
+      // should have the 'auto' behavior of scrolling as little as possible.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 5, rowIndex: 5, align: 'smart' });
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 10, rowIndex: 10, align: 'smart' });
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
     it('should not report isScrolling', () => {
       // Use ReactDOM renderer so the container ref and "onScroll" event work correctly.
       const instance = ReactDOM.render(

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -455,6 +455,34 @@ describe('FixedSizeList', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
+    it('should scroll to the correct item for align = "smart"', () => {
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeList {...defaultProps} />
+      );
+      // Scroll down enough to show item 10 in the middle.
+      rendered.getInstance().scrollToItem(10, 'smart');
+      // Scrolldn't scroll at all because it's close enough.
+      rendered.getInstance().scrollToItem(9, 'smart');
+      // Should scroll but not center because it's close enough.
+      rendered.getInstance().scrollToItem(6, 'smart');
+      // Item 1 can't align in the middle because it's too close to the beginning.
+      // Scroll up as far as possible though.
+      rendered.getInstance().scrollToItem(1, 'smart');
+      // Item 99 can't align in the middle because it's too close to the end.
+      // Scroll down as far as possible though.
+      rendered.getInstance().scrollToItem(99, 'smart');
+      // This shouldn't scroll at all because it's close enough.
+      rendered.getInstance().scrollToItem(95, 'smart');
+      rendered.getInstance().scrollToItem(99, 'smart');
+      // This should scroll with the 'auto' behavior because it's within a screen.
+      rendered.getInstance().scrollToItem(94, 'smart');
+      rendered.getInstance().scrollToItem(99, 'smart');
+      // This should scroll with the 'center' behavior because it's too far.
+      rendered.getInstance().scrollToItem(90, 'smart');
+      rendered.getInstance().scrollToItem(99, 'smart');
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
     it('should not report isScrolling', () => {
       // Use ReactDOM renderer so the container ref and "onScroll" work correctly.
       const instance = ReactDOM.render(

--- a/src/__tests__/VariableSizeGrid.js
+++ b/src/__tests__/VariableSizeGrid.js
@@ -273,6 +273,41 @@ describe('VariableSizeGrid', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
+    it('should scroll to the correct item for align = "smart"', () => {
+      const rendered = ReactTestRenderer.create(
+        <VariableSizeGrid {...defaultProps} />
+      );
+
+      // Scroll down enough to show item 10 at the center.
+      // It was further than one screen away, so it gets centered.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 10, rowIndex: 10, align: 'smart' });
+      // No need to scroll again; item 9 is already visible.
+      // Overscan indices will change though, since direction changes.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 9, rowIndex: 9, align: 'smart' });
+      // Scroll up enough to show item 2 as close to the center as we can.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 2, rowIndex: 2, align: 'smart' });
+      // Scroll down to row 10, without changing scrollLeft
+      rendered.getInstance().scrollToItem({ rowIndex: 10, align: 'smart' });
+      // Scroll left to column 0, without changing scrollTop
+      rendered.getInstance().scrollToItem({ columnIndex: 0, align: 'smart' });
+
+      // Scrolling within a distance of a single screen from viewport
+      // should have the 'auto' behavior of scrolling as little as possible.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 5, rowIndex: 5, align: 'smart' });
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 10, rowIndex: 10, align: 'smart' });
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
     it('should account for scrollbar size', () => {
       const onScroll = jest.fn();
       const rendered = ReactTestRenderer.create(

--- a/src/__tests__/VariableSizeList.js
+++ b/src/__tests__/VariableSizeList.js
@@ -197,6 +197,23 @@ describe('VariableSizeList', () => {
       rendered.getInstance().scrollToItem(19, 'center');
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
+
+    it('should scroll to the correct item for align = "smart"', () => {
+      const onItemsRendered = jest.fn();
+      const rendered = ReactTestRenderer.create(
+        <VariableSizeList {...defaultProps} onItemsRendered={onItemsRendered} />
+      );
+      // Scroll down enough to show item 10 in the middle.
+      rendered.getInstance().scrollToItem(10, 'smart');
+      // Scrolldn't scroll at all because it's close enough.
+      rendered.getInstance().scrollToItem(9, 'smart');
+      // Should scroll but not center because it's close enough.
+      rendered.getInstance().scrollToItem(6, 'smart');
+      // Item 1 can't align in the middle because it's too close to the beginning.
+      // Scroll up as far as possible though.
+      rendered.getInstance().scrollToItem(1, 'smart');
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
   });
 
   describe('resetAfterIndex method', () => {

--- a/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
@@ -540,6 +540,95 @@ Array [
 ]
 `;
 
+exports[`FixedSizeGrid scrollToItem method should scroll to the correct item for align = "smart" 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 3,
+      "overscanRowStartIndex": 0,
+      "overscanRowStopIndex": 5,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 2,
+      "visibleRowStartIndex": 0,
+      "visibleRowStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 8,
+      "overscanColumnStopIndex": 12,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 9,
+      "visibleColumnStopIndex": 11,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 0,
+      "overscanRowStopIndex": 6,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 1,
+      "visibleRowStopIndex": 5,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 3,
+      "overscanRowStartIndex": 7,
+      "overscanRowStopIndex": 13,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 2,
+      "visibleRowStartIndex": 8,
+      "visibleRowStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 3,
+      "overscanColumnStopIndex": 7,
+      "overscanRowStartIndex": 4,
+      "overscanRowStopIndex": 10,
+      "visibleColumnStartIndex": 4,
+      "visibleColumnStopIndex": 6,
+      "visibleRowStartIndex": 5,
+      "visibleRowStopIndex": 9,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 8,
+      "overscanColumnStopIndex": 12,
+      "overscanRowStartIndex": 6,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 9,
+      "visibleColumnStopIndex": 11,
+      "visibleRowStartIndex": 7,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeGrid scrollToItem method should scroll to the correct item for align = "start" 1`] = `
 Array [
   Array [

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -292,6 +292,99 @@ Array [
 ]
 `;
 
+exports[`FixedSizeList scrollToItem method should scroll to the correct item for align = "smart" 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 6,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 6,
+      "overscanStopIndex": 14,
+      "visibleStartIndex": 8,
+      "visibleStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 4,
+      "overscanStopIndex": 12,
+      "visibleStartIndex": 6,
+      "visibleStopIndex": 10,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 6,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 93,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 95,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 92,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 94,
+      "visibleStopIndex": 98,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 86,
+      "overscanStopIndex": 94,
+      "visibleStartIndex": 88,
+      "visibleStopIndex": 92,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeList scrollToItem method should scroll to the correct item for align = "start" 1`] = `
 Array [
   Array [

--- a/src/__tests__/__snapshots__/VariableSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/VariableSizeGrid.js.snap
@@ -221,6 +221,95 @@ Array [
 ]
 `;
 
+exports[`VariableSizeGrid scrollToItem method should scroll to the correct item for align = "smart" 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 0,
+      "overscanRowStopIndex": 4,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 0,
+      "visibleRowStopIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 5,
+      "overscanColumnStopIndex": 9,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 6,
+      "visibleColumnStopIndex": 9,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 0,
+      "overscanRowStopIndex": 5,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 4,
+      "visibleRowStartIndex": 1,
+      "visibleRowStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 5,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 1,
+      "visibleColumnStopIndex": 4,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 0,
+      "overscanColumnStopIndex": 4,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 0,
+      "visibleColumnStopIndex": 3,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 1,
+      "overscanColumnStopIndex": 6,
+      "overscanRowStartIndex": 2,
+      "overscanRowStopIndex": 8,
+      "visibleColumnStartIndex": 2,
+      "visibleColumnStopIndex": 5,
+      "visibleRowStartIndex": 3,
+      "visibleRowStopIndex": 7,
+    },
+  ],
+  Array [
+    Object {
+      "overscanColumnStartIndex": 5,
+      "overscanColumnStopIndex": 9,
+      "overscanRowStartIndex": 8,
+      "overscanRowStopIndex": 12,
+      "visibleColumnStartIndex": 6,
+      "visibleColumnStopIndex": 9,
+      "visibleRowStartIndex": 9,
+      "visibleRowStopIndex": 11,
+    },
+  ],
+]
+`;
+
 exports[`VariableSizeGrid scrollToItem method should scroll to the correct item for align = "start" 1`] = `
 Array [
   Array [

--- a/src/__tests__/__snapshots__/VariableSizeList.js.snap
+++ b/src/__tests__/__snapshots__/VariableSizeList.js.snap
@@ -150,6 +150,43 @@ Array [
 ]
 `;
 
+exports[`VariableSizeList scrollToItem method should scroll to the correct item for align = "smart" 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 7,
+      "overscanStopIndex": 13,
+      "visibleStartIndex": 9,
+      "visibleStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 4,
+      "overscanStopIndex": 11,
+      "visibleStartIndex": 6,
+      "visibleStopIndex": 9,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 6,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 4,
+    },
+  ],
+]
+`;
+
 exports[`VariableSizeList scrollToItem method should scroll to the correct item for align = "start" 1`] = `
 Array [
   Array [

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -8,7 +8,7 @@ import { getScrollbarSize } from './domHelpers';
 import type { TimeoutID } from './timer';
 
 type Direction = 'ltr' | 'rtl';
-export type ScrollToAlign = 'auto' | 'center' | 'start' | 'end';
+export type ScrollToAlign = 'auto' | 'smart' | 'center' | 'start' | 'end';
 
 type itemSize = number | ((index: number) => number);
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -6,7 +6,7 @@ import { cancelTimeout, requestTimeout } from './timer';
 
 import type { TimeoutID } from './timer';
 
-export type ScrollToAlign = 'auto' | 'center' | 'start' | 'end';
+export type ScrollToAlign = 'auto' | 'smart' | 'center' | 'start' | 'end';
 
 type itemSize = number | ((index: number) => number);
 // TODO Deprecate directions "horizontal" and "vertical"


### PR DESCRIPTION
This adds implementation + tests. I can write the docs if you'd like them to be a part of the PR.

The purpose is to add a new scrolling mode called `smart`. We may make it default in v2 if we want.

It behaves like `auto` when the target is *within a single screen from the viewport boundaries*, and behaves like `center` otherwise. The rationale is that if something is far enough, there's no meaningful context to preserve — and therefore we might as well center it.

In particular, centering is helpful for cases when the next selected item is relatively random (such as with "find by DOM node" picker in DevTools). In that case, the `auto` behavior often jumps between the top and the bottom selected nodes because we're not necessarily scrolling in any particular direction. However, the `smart` behavior tries to center things unless we're already pretty close to them.

### Before

![Screen Recording 2019-04-12 at 06 09 PM](https://user-images.githubusercontent.com/810438/56054280-5a942000-5d4e-11e9-9164-5aea3cc072c1.gif)


### After

![Screen Recording 2019-04-12 at 06 08 PM](https://user-images.githubusercontent.com/810438/56054298-697ad280-5d4e-11e9-9b80-a9140a04ccdb.gif)
