### PR TITLE
List components: add 'useIsVisible' prop

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -870,4 +870,28 @@ describe('FixedSizeList', () => {
       );
     });
   });
+
+  describe('useIsVisible', () => {
+    it('should not pass an isVisible prop to children unless requested', () => {
+      ReactTestRenderer.create(<FixedSizeList {...defaultProps} />);
+      expect(itemRenderer.mock.calls[0][0].isVisible).toBeUndefined();
+    });
+
+    it('should pass an isVisible prop to children if requested', () => {
+      ReactTestRenderer.create(
+        <FixedSizeList {...defaultProps} useIsVisible />
+      );
+      expect(itemRenderer.mock.calls[0][0].isVisible).toBeDefined();
+    });
+
+    it('should pass an accurate isVisible prop to children', () => {
+      ReactTestRenderer.create(
+        <FixedSizeList {...defaultProps} useIsVisible />
+      );
+
+      expect(itemRenderer).toHaveBeenCalledTimes(7);
+      expect(itemRenderer.mock.calls[0][0].isVisible).toBe(true);
+      expect(itemRenderer.mock.calls[6][0].isVisible).toBe(false);
+    });
+  });
 });

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -17,6 +17,7 @@ type RenderComponentProps<T> = {|
   data: T,
   index: number,
   isScrolling?: boolean,
+  isVisible?: boolean,
   style: Object,
 |};
 type RenderComponent<T> = React$ComponentType<$Shape<RenderComponentProps<T>>>;
@@ -151,6 +152,7 @@ export default function createListComponent({
       layout: 'vertical',
       overscanCount: 2,
       useIsScrolling: false,
+      useIsVisible: false,
     };
 
     state: State = {

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -60,6 +60,7 @@ export type Props<T> = {|
   overscanCount: number,
   style?: Object,
   useIsScrolling: boolean,
+  useIsVisible: boolean,
   width: number | string,
 |};
 
@@ -268,6 +269,7 @@ export default function createListComponent({
         outerTagName,
         style,
         useIsScrolling,
+        useIsVisible,
         width,
       } = this.props;
       const { isScrolling } = this.state;
@@ -280,7 +282,12 @@ export default function createListComponent({
         ? this._onScrollHorizontal
         : this._onScrollVertical;
 
-      const [startIndex, stopIndex] = this._getRangeToRender();
+      const [
+        startIndex,
+        stopIndex,
+        visibleStartIndex,
+        visibleStopIndex,
+      ] = this._getRangeToRender();
 
       const items = [];
       if (itemCount > 0) {
@@ -291,6 +298,9 @@ export default function createListComponent({
               key: itemKey(index, itemData),
               index,
               isScrolling: useIsScrolling ? isScrolling : undefined,
+              isVisible: useIsVisible
+                ? index >= visibleStartIndex && index <= visibleStopIndex
+                : undefined,
               style: this._getItemStyle(index),
             })
           );

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -26,8 +26,10 @@ const PROPS = [
           a <code>style</code> prop (used for positioning).
         </p>
         <p>
-          If <code>useIsScrolling</code> is enabled for the list, the component
-          also receives an additional <code>isScrolling</code> boolean prop.
+          If <code>useIsScrolling</code> or <code>useIsVisible</code> are
+          enabled for the list, the component also receives an additional{' '}
+          <code>isScrolling</code> or <code>isVisible</code> boolean prop,
+          respectively.
         </p>
         <p>Function components are useful for rendering simple items:</p>
         <div className={styles.CodeBlockWrapper}>
@@ -358,6 +360,19 @@ const PROPS = [
       </Fragment>
     ),
     name: 'useIsScrolling',
+    type: 'boolean',
+  },
+  {
+    defaultValue: false,
+    description: (
+      <Fragment>
+        <p>
+          Adds an additional <code>isVisible</code> parameter to the{' '}
+          <code>children</code> render function.
+        </p>
+      </Fragment>
+    ),
+    name: 'useIsVisible',
     type: 'boolean',
   },
   {


### PR DESCRIPTION
With `react-virtualized` we use the `isVisible` prop from `rowRenderer` to conditionally render a "lightweight" version of the row. This feature doesn't exist in `react-window` but it seemed straightforward to add.

I attempted to implement this in our app by getting the visible index data from `onItemsRendered` and passing that along to `itemData` but it did not seem like it would be the most performant solution. 

I'm open to feedback about whether this feature is useful or if there are other patterns that would be preferable. 