### PR TITLE
export getScrollbarSize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ export { default as FixedSizeList } from './FixedSizeList';
 
 export { default as areEqual } from './areEqual';
 export { default as shouldComponentUpdate } from './shouldComponentUpdate';
+export { getScrollbarSize } from './domHelpers';


### PR DESCRIPTION
that would be useful if we need that helper and don't need to dupe the code again