### PR TITLE
Fix scrolling issues in RTL in Chrome, Firefox and Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "flow-bin": "^0.80.0",
     "gh-pages": "^1.1.0",
     "lint-staged": "^7.0.5",
+    "normalize-scroll-left": "^0.1.2",
+    "path": "^0.12.7",
     "prettier": "^1.12.1",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "memoize-one": ">=3.1.1 <6"
+    "memoize-one": ">=3.1.1 <6",
+    "normalize-scroll-left": "^0.1.2"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",
@@ -94,7 +95,6 @@
     "flow-bin": "^0.80.0",
     "gh-pages": "^1.1.0",
     "lint-staged": "^7.0.5",
-    "normalize-scroll-left": "^0.1.2",
     "path": "^0.12.7",
     "prettier": "^1.12.1",
     "react": "^16.8.4",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
@@ -6,7 +7,7 @@ import pkg from './package.json';
 
 const input = './src/index.js';
 
-const external = id => !id.startsWith('.') && !id.startsWith('/');
+const external = id => !id.startsWith('.') && !path.isAbsolute(id);
 
 export default [
   {

--- a/src/__tests__/RTL.js
+++ b/src/__tests__/RTL.js
@@ -1,0 +1,359 @@
+import React, { createRef } from 'react';
+import { render } from 'react-dom';
+import { Simulate } from 'react-dom/test-utils';
+import { _setScrollType } from 'normalize-scroll-left';
+import { FixedSizeGrid, FixedSizeList } from '..';
+
+describe('RTL', () => {
+  let rendering;
+  let container;
+  let itemRenderer;
+  let defaultProps;
+  let outerRef;
+  let onScroll;
+
+  beforeEach(() => {
+    onScroll = jest.fn();
+    container = document.createElement('div');
+    itemRenderer = jest.fn(({ style, ...rest }) => (
+      <div style={style}>{JSON.stringify(rest, null, 2)}</div>
+    ));
+
+    outerRef = createRef();
+  });
+
+  afterEach(() => {
+    _setScrollType(undefined);
+  });
+
+  function simulateScroll(scrollLeft) {
+    outerRef.current.scrollLeft = scrollLeft;
+    Simulate.scroll(outerRef.current);
+  }
+
+  describe('FixedSizedGrid', () => {
+    function createGridAndSetWidths() {
+      rendering = render(<FixedSizeGrid {...defaultProps} />, container);
+      Object.defineProperties(outerRef.current, {
+        clientWidth: { writable: true },
+        scrollWidth: { writable: true },
+      });
+      outerRef.current.clientWidth = 200;
+      outerRef.current.scrollWidth = 1000;
+
+      itemRenderer.mockClear();
+      onScroll.mockClear();
+    }
+
+    function expectColumnRendered(column) {
+      expect(
+        itemRenderer.mock.calls.find(
+          ([params]) => params.columnIndex === column
+        )
+      ).toBeTruthy();
+    }
+
+    function expectColumnNotRendered(column) {
+      expect(
+        itemRenderer.mock.calls.find(
+          ([params]) => params.columnIndex === column
+        )
+      ).toBeFalsy();
+    }
+
+    function testUserScrollingHorizontally(scrollLeft) {
+      describe(`when the user scrolls horizontally to ${scrollLeft}`, () => {
+        beforeEach(() => {
+          simulateScroll(scrollLeft);
+        });
+
+        it('renders columns 2 to 6', () => {
+          expectColumnNotRendered(0);
+          expectColumnNotRendered(1);
+          expectColumnRendered(2);
+          expectColumnRendered(3);
+          expectColumnRendered(4);
+          expectColumnRendered(5);
+          expectColumnRendered(6);
+          expectColumnNotRendered(7);
+          expectColumnNotRendered(8);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollLeft,
+            scrollTop: 0,
+            horizontalScrollDirection: 'forward',
+            verticalScrollDirection: 'backward',
+            scrollUpdateWasRequested: false,
+          });
+        });
+      });
+    }
+
+    function testScrollToCall(scrollLeft) {
+      describe(`when scrollTo is called with ${scrollLeft}`, () => {
+        beforeEach(() => {
+          rendering.scrollTo({ scrollLeft });
+        });
+
+        it('renders correctly when the user scrolls', () => {
+          expectColumnNotRendered(0);
+          expectColumnNotRendered(1);
+          expectColumnNotRendered(2);
+          expectColumnNotRendered(3);
+          expectColumnRendered(4);
+          expectColumnRendered(5);
+          expectColumnRendered(6);
+          expectColumnRendered(7);
+          expectColumnRendered(8);
+          expectColumnNotRendered(9);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollLeft,
+            scrollTop: 0,
+            horizontalScrollDirection: 'forward',
+            verticalScrollDirection: 'backward',
+            scrollUpdateWasRequested: true,
+          });
+        });
+      });
+    }
+
+    function testWhenScrollToItemCalledWith7(scrollLeft) {
+      describe('when scrolled to column 7', () => {
+        beforeEach(() => {
+          rendering.scrollToItem({ columnIndex: 7 });
+        });
+
+        it(`sets scrollLeft to ${scrollLeft}`, () => {
+          expect(outerRef.current.scrollLeft).toEqual(scrollLeft);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollLeft,
+            scrollTop: 0,
+            horizontalScrollDirection: 'forward',
+            verticalScrollDirection: 'backward',
+            scrollUpdateWasRequested: true,
+          });
+        });
+      });
+    }
+
+    beforeEach(() => {
+      defaultProps = {
+        children: itemRenderer,
+        columnCount: 10,
+        columnWidth: 100,
+        height: 100,
+        rowCount: 20,
+        rowHeight: 100,
+        width: 200,
+        direction: 'rtl',
+        outerRef,
+        onScroll,
+      };
+    });
+
+    describe('default scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('default');
+        createGridAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(500);
+
+      testScrollToCall(300);
+
+      testWhenScrollToItemCalledWith7(200);
+    });
+
+    describe('reverse scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('reverse');
+        createGridAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(300);
+
+      testScrollToCall(500);
+
+      testWhenScrollToItemCalledWith7(600);
+    });
+
+    describe('negative scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('negative');
+        createGridAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(-300);
+
+      testScrollToCall(-500);
+
+      testWhenScrollToItemCalledWith7(-600);
+    });
+  });
+
+  describe('FixedSizedList', () => {
+    function createListAndSetWidths() {
+      rendering = render(<FixedSizeList {...defaultProps} />, container);
+      Object.defineProperties(outerRef.current, {
+        clientWidth: { writable: true },
+        scrollWidth: { writable: true },
+      });
+      outerRef.current.clientWidth = 200;
+      outerRef.current.scrollWidth = 1000;
+
+      itemRenderer.mockClear();
+      onScroll.mockClear();
+    }
+
+    function expectItemRendered(column) {
+      expect(
+        itemRenderer.mock.calls.find(([params]) => params.index === column)
+      ).toBeTruthy();
+    }
+
+    function expectItemNotRendered(column) {
+      expect(
+        itemRenderer.mock.calls.find(([params]) => params.index === column)
+      ).toBeFalsy();
+    }
+
+    function testUserScrollingHorizontally(scrollLeft) {
+      describe(`when the user scrolls horizontally to ${scrollLeft}`, () => {
+        beforeEach(() => {
+          simulateScroll(scrollLeft);
+        });
+
+        it('renders columns 2 to 6', () => {
+          expectItemNotRendered(0);
+          expectItemNotRendered(1);
+          expectItemRendered(2);
+          expectItemRendered(3);
+          expectItemRendered(4);
+          expectItemRendered(5);
+          expectItemRendered(6);
+          expectItemNotRendered(7);
+          expectItemNotRendered(8);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollOffset: scrollLeft,
+            scrollDirection: 'forward',
+            scrollUpdateWasRequested: false,
+          });
+        });
+      });
+    }
+
+    function testScrollToCall(scrollLeft) {
+      describe(`when scrollTo is called with ${scrollLeft}`, () => {
+        beforeEach(() => {
+          rendering.scrollTo(scrollLeft);
+        });
+
+        it('renders correctly when the user scrolls', () => {
+          expectItemNotRendered(0);
+          expectItemNotRendered(1);
+          expectItemNotRendered(2);
+          expectItemNotRendered(3);
+          expectItemRendered(4);
+          expectItemRendered(5);
+          expectItemRendered(6);
+          expectItemRendered(7);
+          expectItemRendered(8);
+          expectItemNotRendered(9);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollOffset: scrollLeft,
+            scrollDirection: 'forward',
+            scrollUpdateWasRequested: true,
+          });
+        });
+      });
+    }
+
+    function testWhenScrollToItemCalledWith7(scrollLeft) {
+      describe('when scrolled to column 7', () => {
+        beforeEach(() => {
+          rendering.scrollToItem(7);
+        });
+
+        it(`sets scrollLeft to ${scrollLeft}`, () => {
+          expect(outerRef.current.scrollLeft).toEqual(scrollLeft);
+        });
+
+        it('reports onScroll as the browser sees it', () => {
+          expect(onScroll).toHaveBeenCalledWith({
+            scrollOffset: scrollLeft,
+            scrollDirection: 'forward',
+            scrollUpdateWasRequested: true,
+          });
+        });
+      });
+    }
+
+    beforeEach(() => {
+      defaultProps = {
+        children: itemRenderer,
+        itemCount: 10,
+        itemSize: 100,
+        height: 100,
+        width: 200,
+        layout: 'horizontal',
+        direction: 'rtl',
+        overscanCount: 1,
+        outerRef,
+        onScroll,
+      };
+    });
+
+    describe('default scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('default');
+        createListAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(500);
+
+      testScrollToCall(300);
+
+      testWhenScrollToItemCalledWith7(200);
+    });
+
+    describe('reverse scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('reverse');
+        createListAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(300);
+
+      testScrollToCall(500);
+
+      testWhenScrollToItemCalledWith7(600);
+    });
+
+    describe('negative scrollType', () => {
+      beforeEach(() => {
+        _setScrollType('negative');
+        createListAndSetWidths();
+      });
+
+      testUserScrollingHorizontally(-300);
+
+      testScrollToCall(-500);
+
+      testWhenScrollToItemCalledWith7(-600);
+    });
+  });
+});

--- a/src/__tests__/RTL.js
+++ b/src/__tests__/RTL.js
@@ -356,4 +356,144 @@ describe('RTL', () => {
       testWhenScrollToItemCalledWith7(-600);
     });
   });
+
+  describe('When there is enough space to render all items', () => {
+    describe('List', () => {
+      beforeEach(() => {
+        defaultProps = {
+          children: itemRenderer,
+          itemCount: 4,
+          itemSize: 100,
+          height: 100,
+          width: 800,
+          layout: 'horizontal',
+          direction: 'rtl',
+          overscanCount: 1,
+          outerRef,
+          onScroll,
+        };
+      });
+
+      function createListAndSetWidths() {
+        rendering = render(<FixedSizeList {...defaultProps} />, container);
+        Object.defineProperties(outerRef.current, {
+          clientWidth: { writable: true },
+          scrollWidth: { writable: true },
+        });
+        outerRef.current.clientWidth = 800;
+        outerRef.current.scrollWidth = 800;
+
+        itemRenderer.mockClear();
+        onScroll.mockClear();
+      }
+
+      function testWhenScrollToItemCalledWith2() {
+        describe('when scrolled to column 2', () => {
+          beforeEach(() => {
+            rendering.scrollToItem(2);
+          });
+
+          it('does not report onScroll', () => {
+            expect(onScroll).not.toHaveBeenCalled();
+          });
+        });
+      }
+
+      describe('default scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('default');
+          createListAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWith2();
+      });
+
+      describe('reverse scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('reverse');
+          createListAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWith2();
+      });
+
+      describe('negative scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('negative');
+          createListAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWith2();
+      });
+    });
+
+    describe('Grid', () => {
+      beforeEach(() => {
+        defaultProps = {
+          children: itemRenderer,
+          columnCount: 4,
+          columnWidth: 100,
+          height: 800,
+          rowCount: 4,
+          rowHeight: 100,
+          width: 800,
+          direction: 'rtl',
+          outerRef,
+          onScroll,
+        };
+      });
+
+      function createGridAndSetWidths() {
+        rendering = render(<FixedSizeGrid {...defaultProps} />, container);
+        Object.defineProperties(outerRef.current, {
+          clientWidth: { writable: true },
+          scrollWidth: { writable: true },
+        });
+        outerRef.current.clientWidth = 800;
+        outerRef.current.scrollWidth = 800;
+
+        itemRenderer.mockClear();
+        onScroll.mockClear();
+      }
+
+      function testWhenScrollToItemCalledWithCol2() {
+        describe('when scrolled to column 2', () => {
+          beforeEach(() => {
+            rendering.scrollToItem({ columnIndex: 2 });
+          });
+
+          it('does not report onScroll', () => {
+            expect(onScroll).not.toHaveBeenCalled();
+          });
+        });
+      }
+
+      describe('default scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('default');
+          createGridAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWithCol2();
+      });
+
+      describe('reverse scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('reverse');
+          createGridAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWithCol2();
+      });
+
+      describe('negative scrollType', () => {
+        beforeEach(() => {
+          _setScrollType('negative');
+          createGridAndSetWidths();
+        });
+
+        testWhenScrollToItemCalledWithCol2();
+      });
+    });
+  });
 });

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -206,7 +206,7 @@ export default function createGridComponent({
           : normalizeScrollLeft({
               direction: direction,
               scrollLeft: 0,
-              clientWidth: width,
+              clientWidth: Math.min(width, estimatedWidth),
               scrollWidth: estimatedWidth,
             });
 
@@ -409,7 +409,8 @@ export default function createGridComponent({
           direction,
           scrollLeft: newNormalizedScrollLeft,
           scrollWidth: newEstimatedTotalWidth,
-          clientWidth: width - verticalScrollbarSize,
+          clientWidth:
+            Math.min(width, newEstimatedTotalWidth) - verticalScrollbarSize,
         });
       }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -177,7 +177,7 @@ export default function createListComponent({
             : normalizeScrollLeft({
                 direction: mappedDirection,
                 scrollLeft: 0,
-                clientWidth: ((width: any): number),
+                clientWidth: Math.min(((width: any): number), estimatedWidth),
                 scrollWidth: estimatedWidth,
               });
 
@@ -323,7 +323,10 @@ export default function createListComponent({
           direction: this._mappedDirectionForNormalization(),
           scrollLeft: newNormalizedScrollOffset,
           scrollWidth: newEstimatedTotalWidth,
-          clientWidth: this._widthPropAsNumber(),
+          clientWidth: Math.min(
+            this._widthPropAsNumber(),
+            newEstimatedTotalWidth
+          ),
         });
       } else {
         browserOffset = getOffsetForIndexAndAlignment(

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -41,12 +41,9 @@ export function normalizeScrollLeft(props: NormalizeScrollLeftProps): number {
   switch (detectScrollType()) {
     case 'negative':
       return -props.scrollLeft;
-      break;
     case 'reverse':
       return props.scrollLeft;
-      break;
     default:
       return props.scrollWidth - props.clientWidth - props.scrollLeft;
-      break;
   }
 }

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { detectScrollType } from 'normalize-scroll-left';
+
 let size: number = -1;
 
 // This utility copied from "dom-helpers" package.
@@ -19,4 +21,32 @@ export function getScrollbarSize(recalculate?: boolean = false): number {
   }
 
   return size;
+}
+
+type NormalizeScrollLeftProps = {
+  direction: 'ltr' | 'rtl',
+  scrollLeft: number,
+  scrollWidth: number,
+  clientWidth: number,
+};
+
+// According to the spec, scrollLeft should be negative for RTL aligned elements.
+// Chrome and Edge do not seem to adhere; Chromes scrollLeft values are positive (measured relative to the left), Edges are reversed
+// See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft
+export function normalizeScrollLeft(props: NormalizeScrollLeftProps): number {
+  if (props.direction === 'ltr') {
+    return props.scrollLeft;
+  }
+
+  switch (detectScrollType()) {
+    case 'negative':
+      return -props.scrollLeft;
+      break;
+    case 'reverse':
+      return props.scrollLeft;
+      break;
+    default:
+      return props.scrollWidth - props.clientWidth - props.scrollLeft;
+      break;
+  }
 }

--- a/website/src/routes/examples/ScrollToItem.js
+++ b/website/src/routes/examples/ScrollToItem.js
@@ -83,6 +83,12 @@ export default class ScrollToItem extends PureComponent {
             >
               Scroll to row 300 (align: center)
             </button>
+            <button
+              className={styles.ExampleButton}
+              onClick={this.scrollTo10000}
+            >
+              Scroll to 10000
+            </button>
             <VariableSizeList
               className={styles.List}
               height={150}
@@ -90,6 +96,8 @@ export default class ScrollToItem extends PureComponent {
               itemSize={index => rowHeights[index]}
               ref={this.listRef}
               width={300}
+              layout="horizontal"
+              direction="rtl"
             >
               {ListItemRenderer}
             </VariableSizeList>
@@ -145,6 +153,30 @@ export default class ScrollToItem extends PureComponent {
             >
               Scroll to column 50 (align: auto)
             </button>
+            <button
+              className={styles.ExampleButton}
+              onClick={this.scrollToColumn950Auto}
+            >
+              Scroll to column 950 (align: auto)
+            </button>
+            <button
+              className={styles.ExampleButton}
+              onClick={this.scrollTo100100}
+            >
+              Scroll to 100,100
+            </button>
+            <button
+              className={styles.ExampleButton}
+              onClick={this.scrollTo50000100}
+            >
+              Scroll to 50000,100
+            </button>
+            <button
+              className={styles.ExampleButton}
+              onClick={this.scrollTo99000100}
+            >
+              Scroll to 99000,100
+            </button>
             <VariableSizeGrid
               className={styles.Grid}
               columnCount={1000}
@@ -154,6 +186,7 @@ export default class ScrollToItem extends PureComponent {
               rowCount={1000}
               rowHeight={index => rowHeights[index]}
               width={300}
+              direction="rtl"
             >
               {GridItemRenderer}
             </VariableSizeGrid>
@@ -166,9 +199,36 @@ export default class ScrollToItem extends PureComponent {
     );
   }
 
+  scrollTo100100 = () => {
+    this.gridRef.current.scrollTo({
+      scrollLeft: 100,
+      scrollTop: 100,
+    });
+  };
+
+  scrollTo50000100 = () => {
+    this.gridRef.current.scrollTo({
+      scrollLeft: 50000,
+      scrollTop: 100,
+    });
+  };
+
+  scrollTo99000100 = () => {
+    this.gridRef.current.scrollTo({
+      scrollLeft: 99000,
+      scrollTop: 100,
+    });
+  };
+
   scrollToColumn50Auto = () => {
     this.gridRef.current.scrollToItem({
       columnIndex: 50,
+    });
+  };
+
+  scrollToColumn950Auto = () => {
+    this.gridRef.current.scrollToItem({
+      columnIndex: 950,
     });
   };
 
@@ -180,6 +240,9 @@ export default class ScrollToItem extends PureComponent {
     trace('scroll to row 300', performance.now(), () =>
       this.listRef.current.scrollToItem(300, 'center')
     );
+  scrollTo10000 = () => trace('scroll to 10000', performance.now(), () =>
+    this.listRef.current.scrollTo(10000)
+  );
 
   scrollToRow250Smart = () => {
     trace('scroll to row 250', performance.now(), () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5937,6 +5937,11 @@ normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
 
+normalize-scroll-left@^0.1.2:
+  version "0.1.2"
+  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
+  integrity sha1-a3lpG6eetfsQf6Xt+9wGtVyu4qo=
+
 normalize-url@^1.4.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
@@ -6312,6 +6317,14 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path@^0.12.7:
+  version "0.12.7"
+  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
+  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  dependencies:
+    process "^0.11.1"
+    util "^0.10.3"
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -6716,9 +6729,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-process@^0.11.10:
+process@^0.11.1, process@^0.11.10:
   version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,8 +5939,7 @@ normalize-range@^0.1.2:
 
 normalize-scroll-left@^0.1.2:
   version "0.1.2"
-  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
-  integrity sha1-a3lpG6eetfsQf6Xt+9wGtVyu4qo=
+  resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
 
 normalize-url@^1.4.0:
   version "1.9.1"
@@ -6320,8 +6319,7 @@ path-type@^2.0.0:
 
 path@^0.12.7:
   version "0.12.7"
-  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
-  integrity sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
+  resolved "https://registry.yarnpkg.com/path/-/path-0.12.7.tgz#d4dc2a506c4ce2197eb481ebfcd5b36c0140b10f"
   dependencies:
     process "^0.11.1"
     util "^0.10.3"
@@ -6731,8 +6729,7 @@ process-nextick-args@~2.0.0:
 
 process@^0.11.1, process@^0.11.10:
   version "0.11.10"
-  resolved "https://eu.artifactory.swg-devops.com:443/artifactory/api/npm/sec-ibmi2-npm/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
 progress@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hopefully this fixes #159 and fixes #198.

The code is essentially now keeping an internal normalized representation of scrollLeft which is used as scrollLeft used to be to determine the indices to be rendered. Anywhere that scrollLeft is reported out or received in, e.g. `onScroll` and `scrollTo` it reports and expects scrollLeft as the browser would represent it.

I've used the `normalize-scroll-left` library to determine what type of scrolling the current browser implements.

I've changed the ScrollToItem file to make it easier to see the changes in action hopefully proving the validity of the code changes.