### PR TITLE
Adds range rendering

### DIFF
--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -4,6 +4,7 @@ import ReactTestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
 import { FixedSizeGrid } from '..';
 import * as domHelpers from '../domHelpers';
+import { defaultCellRangeRenderer } from '../createGridComponent';
 
 const findScrollContainer = rendered => rendered.root.children[0].children[0];
 
@@ -1083,6 +1084,54 @@ describe('FixedSizeGrid', () => {
           'Grids must specify a number for width. ' +
           '"string" was specified.'
       );
+    });
+  });
+
+  describe('cellRangeRenderer', () => {
+    it('should use a custom cellRangeRenderer if specified', () => {
+      const width = 90;
+      const height = 70;
+      const columnWidth = 20;
+      const rowHeight = 40;
+      const overscanRowsCount = 1;
+      const overscanColumnsCount = 1;
+
+      const expectedColumnStopIndex = Math.floor(
+        width / columnWidth + overscanColumnsCount
+      );
+
+      const expectedRowStopIndex = Math.floor(
+        height / rowHeight + overscanRowsCount
+      );
+
+      const CustomRow = props => <div {...props} />;
+      const cellRangeRenderer = jest
+        .fn()
+        .mockImplementation(defaultCellRangeRenderer);
+
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeGrid
+          {...defaultProps}
+          {...{
+            width,
+            height,
+            columnWidth,
+            rowHeight,
+            overscanRowsCount,
+            overscanColumnsCount,
+          }}
+          cellRangeRenderer={cellRangeRenderer}
+        />
+      );
+
+      expect(cellRangeRenderer).toHaveBeenCalledTimes(1);
+      expect(cellRangeRenderer).toHaveBeenCalledWith({
+        columnStartIndex: 0,
+        rowStartIndex: 0,
+        columnStopIndex: expectedColumnStopIndex,
+        rowStopIndex: expectedRowStopIndex,
+        childFactory: expect.any(Function),
+      });
     });
   });
 });

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import ReactTestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
 import { FixedSizeList } from '..';
+import { defaultRowRangeRenderer } from '../createListComponent';
 
 const simulateScroll = (instance, scrollOffset, direction = 'vertical') => {
   if (direction === 'horizontal') {
@@ -868,6 +869,40 @@ describe('FixedSizeList', () => {
           'Horizontal lists must specify a number for width. ' +
           '"string" was specified.'
       );
+    });
+  });
+
+  describe('rowRangeRenderer', () => {
+    it('should use a custom rowRangeRenderer if specified', () => {
+      const height = 70;
+      const itemSize = 40;
+      const overscanCount = 1;
+
+      const expectedStopIndex = Math.floor(height / itemSize + overscanCount);
+
+      const CustomRow = props => <div {...props} />;
+      const rowRangeRenderer = jest
+        .fn()
+        .mockImplementation(defaultRowRangeRenderer);
+
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeList
+          {...defaultProps}
+          {...{
+            height,
+            itemSize,
+            overscanCount,
+          }}
+          rowRangeRenderer={rowRangeRenderer}
+        />
+      );
+
+      expect(rowRangeRenderer).toHaveBeenCalledTimes(1);
+      expect(rowRangeRenderer).toHaveBeenCalledWith({
+        startIndex: 0,
+        stopIndex: expectedStopIndex,
+        childFactory: expect.any(Function),
+      });
     });
   });
 });

--- a/src/__tests__/VariableSizeGrid.js
+++ b/src/__tests__/VariableSizeGrid.js
@@ -4,6 +4,7 @@ import { Simulate } from 'react-dom/test-utils';
 import ReactTestRenderer from 'react-test-renderer';
 import { VariableSizeGrid } from '..';
 import * as domHelpers from '../domHelpers';
+import { defaultCellRangeRenderer } from '../createGridComponent';
 
 const simulateScroll = (instance, { scrollLeft, scrollTop }) => {
   instance._outerRef.scrollLeft = scrollLeft;
@@ -583,5 +584,53 @@ describe('VariableSizeGrid', () => {
     instance.setState({ columnCount: 2, rowCount: 4 });
     expect(innerRef.current.style.height).toEqual('106px');
     expect(innerRef.current.style.width).toEqual('101px');
+  });
+
+  describe('cellRangeRenderer', () => {
+    it('should use a custom cellRangeRenderer if specified', () => {
+      const width = 90;
+      const height = 70;
+      const columnWidth = _ => 20;
+      const rowHeight = _ => 40;
+      const overscanRowsCount = 1;
+      const overscanColumnsCount = 1;
+
+      const expectedColumnStopIndex = Math.floor(
+        width / columnWidth() + overscanColumnsCount
+      );
+
+      const expectedRowStopIndex = Math.floor(
+        height / rowHeight() + overscanRowsCount
+      );
+
+      const CustomRow = props => <div {...props} />;
+      const cellRangeRenderer = jest
+        .fn()
+        .mockImplementation(defaultCellRangeRenderer);
+
+      const rendered = ReactTestRenderer.create(
+        <VariableSizeGrid
+          {...defaultProps}
+          {...{
+            width,
+            height,
+            columnWidth,
+            rowHeight,
+            overscanRowsCount,
+            overscanColumnsCount,
+          }}
+          cellRangeRenderer={cellRangeRenderer}
+        />
+      );
+
+      expect(cellRangeRenderer).toHaveBeenCalledTimes(1);
+      expect(cellRangeRenderer).toHaveBeenCalledWith({
+        columnStartIndex: 0,
+        rowStartIndex: 0,
+        columnStopIndex: expectedColumnStopIndex,
+        rowStopIndex: expectedRowStopIndex,
+        childFactory: expect.any(Function),
+      });
+    });
   });
 });

--- a/src/__tests__/VariableSizeList.js
+++ b/src/__tests__/VariableSizeList.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import { Simulate } from 'react-dom/test-utils';
 import ReactTestRenderer from 'react-test-renderer';
 import { VariableSizeList } from '..';
+import { defaultRowRangeRenderer } from '../createListComponent';
 
 const simulateScroll = (instance, scrollOffset, direction = 'vertical') => {
   if (direction === 'horizontal') {
@@ -348,5 +349,39 @@ describe('VariableSizeList', () => {
     // Decrease itemCount a lot and verify the scroll height is descreased as well.
     instance.setState({ itemCount: 3 });
     expect(innerRef.current.style.height).toEqual('78px');
+  });
+
+  describe('rowRangeRenderer', () => {
+    it('should use a custom rowRangeRenderer if specified', () => {
+      const height = 70;
+      const itemSize = _ => 40;
+      const overscanCount = 1;
+
+      const expectedStopIndex = Math.floor(height / itemSize() + overscanCount);
+
+      const CustomRow = props => <div {...props} />;
+      const rowRangeRenderer = jest
+        .fn()
+        .mockImplementation(defaultRowRangeRenderer);
+
+      const rendered = ReactTestRenderer.create(
+        <VariableSizeList
+          {...defaultProps}
+          {...{
+            height,
+            itemSize,
+            overscanCount,
+          }}
+          rowRangeRenderer={rowRangeRenderer}
+        />
+      );
+
+      expect(rowRangeRenderer).toHaveBeenCalledTimes(1);
+      expect(rowRangeRenderer).toHaveBeenCalledWith({
+        startIndex: 0,
+        stopIndex: expectedStopIndex,
+        childFactory: expect.any(Function),
+      });
+    });
   });
 });

--- a/website/src/code/FixedSizeGridCellRangeRenderer.js
+++ b/website/src/code/FixedSizeGridCellRangeRenderer.js
@@ -1,0 +1,19 @@
+export function defaultCellRangeRenderer<T>({
+  rowStartIndex,
+  rowStopIndex,
+  columnStartIndex,
+  columnStopIndex,
+  childFactory
+}: CellRangeRendererParams<T>): React$Element<RenderComponent<T>>[] {
+  const items = [];
+  // rowStartIndex, rowStopIndex, columnStartIndex, and columnStopIndex are all integers
+  for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
+    for (let columnIndex = columnStartIndex; columnIndex <= columnStopIndex; columnIndex++) {
+      // childFactory is used to create the next item in the grid
+      const child = childFactory({ rowIndex, columnIndex });
+      items.push(child);
+    }
+  }
+  // Return the items to be rendered to the DOM.
+  return items;
+}

--- a/website/src/code/FixedSizeListRowRangeRenderer.js
+++ b/website/src/code/FixedSizeListRowRangeRenderer.js
@@ -1,0 +1,13 @@
+function rowRangeRenderer({ startIndex, stopIndex, childFactory }) {
+  const items = [];
+
+  // startIndex and stopIndex are integers.
+  for (let index = startIndex; index <= stopIndex; index++) {
+    // childFactory is used to retrieve the child that is to be rendered
+    const child = childFactory({ index });
+    items.push(child);
+  }
+
+  // Return the items to be rendered to the DOM.
+  return items;
+}

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -5,6 +5,7 @@ import ComponentApi from '../../components/ComponentApi';
 
 import styles from './shared.module.css';
 
+import CODE_CELL_RANGE_RENDERER from '../../code/FixedSizeGridCellRangeRenderer.js';
 import CODE_CHILDREN_CLASS from '../../code/FixedSizeGridChildrenClass.js';
 import CODE_CHILDREN_FUNCTION from '../../code/FixedSizeGridChildrenFunction.js';
 import CODE_ITEM_DATA from '../../code/FixedSizeGridItemData.js';
@@ -17,6 +18,27 @@ export default () => (
 );
 
 const PROPS = [
+  {
+    description: (
+      <Fragment>
+        <p>
+          By default, lists render cells consecutively without decoration.
+          Occasionally, you may need to render dynamic content that spans
+          multiple cells. In general, this can be handled with the{' '}
+          <code>children</code> prop or the <code>innerElementType</code> prop.
+          However, if you truly need a fine level of control over the rendering
+          mechanism, rendering, you can do so here. This is an advanced
+          property.
+        </p>
+        <div className={styles.CodeBlockWrapper}>
+          <CodeBlock value={CODE_CELL_RANGE_RENDERER} />
+        </div>
+      </Fragment>
+    ),
+    isRequired: false,
+    name: 'cellRangeRenderer',
+    type: 'function',
+  },
   {
     description: (
       <Fragment>

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -10,6 +10,7 @@ import CODE_CHILDREN_FUNCTION from '../../code/FixedSizeListChildrenFunction.js'
 import CODE_ITEM_DATA from '../../code/FixedSizeListItemData.js';
 import CODE_ITEM_KEY from '../../code/FixedSizeListItemKey.js';
 import CODE_ON_ITEMS_RENDERED from '../../code/FixedSizeListOnItemsRendered.js';
+import CODE_ROW_RANGE_RENDERER from '../../code/FixedSizeListRowRangeRenderer.js';
 import CODE_ON_SCROLL from '../../code/FixedSizeListOnScroll.js';
 
 export default () => (
@@ -324,6 +325,27 @@ const PROPS = [
     ),
     name: 'overscanCount',
     type: 'number',
+  },
+  {
+    description: (
+      <Fragment>
+        <p>
+          By default, lists render rows consecutively without decoration.
+          Occasionally, you may need to render dynamic content that spans
+          multiple items. In general, this can be handled with the{' '}
+          <code>children</code> prop or the <code>innerElementType</code> prop.
+          However, if you truly need a fine level of control over the rendering
+          mechanism, rendering, you can do so here. This is an advanced
+          property.
+        </p>
+        <div className={styles.CodeBlockWrapper}>
+          <CodeBlock value={CODE_ROW_RANGE_RENDERER} />
+        </div>
+      </Fragment>
+    ),
+    isRequired: false,
+    name: 'rowRangeRenderer',
+    type: 'function',
   },
   {
     defaultValue: null,


### PR DESCRIPTION
In certain situations, consumers benefit from being able to control how virtualized items are placed, such as when managing aria attributes (where the DOM hierarchy determines accessibility; see
https://www.w3.org/TR/wai-aria-1.1/#grid).

In this pull request, one could fulfill the accessibility requirement with a `cellRangeRenderer` function, such as the example below: 

```js
  const accessibleCellRangeRenderer = ({
    rowStartIndex,
    rowStopIndex,
    columnStartIndex,
    columnStopIndex,
    childFactory,
  }) => {
    const rows = [];
    for (let rowIndex = rowStartIndex; rowIndex <= rowStopIndex; rowIndex++) {
      const rowChildren = [];
      for (
        let columnIndex = columnStartIndex;
        columnIndex <= columnStopIndex;
        columnIndex++
      ) {
        const cell = childFactory({ rowIndex, columnIndex });
        rowChildren.push(cell);
      }
      rows.push(<div role="row">{rowChildren}</div>);
    }

    return rows;
  };
```

Should address https://github.com/bvaughn/react-window/issues/217
