### PR TITLE
Feature add trailing overscan count 

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -254,7 +254,7 @@ describe('FixedSizeList', () => {
     });
   });
 
-  describe('overscanCount', () => {
+  describe('overscanCount and trailingOverscanCount', () => {
     it('should require a minimum of 1 overscan to support tabbing', () => {
       ReactTestRenderer.create(
         <FixedSizeList
@@ -266,17 +266,18 @@ describe('FixedSizeList', () => {
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
-    it('should overscan in the direction being scrolled', () => {
+    it('should overscan "overscanCount" in the direction being scrolled and "trailingOverscanCount" in the opposite direction', () => {
       const instance = ReactDOM.render(
         <FixedSizeList
           {...defaultProps}
           initialScrollOffset={50}
-          overscanCount={2}
+          overscanCount={5}
+          trailingOverscanCount={2}
         />,
         document.createElement('div')
       );
       // Simulate scrolling (rather than using scrollTo) to test isScrolling state.
-      simulateScroll(instance, 100);
+      simulateScroll(instance, 200);
       simulateScroll(instance, 50);
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
@@ -296,6 +297,32 @@ describe('FixedSizeList', () => {
           overscanCount={3}
         />
       );
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('should ignore "trailingOverscanCount" when not scrolling', () => {
+      ReactTestRenderer.create(
+        <FixedSizeList
+          {...defaultProps}
+          initialScrollOffset={100}
+          overscanCount={3}
+          trailingOverscanCount={2}
+        />
+      );
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('should cap "trailingOverscanCount" to "overscanCount"', () => {
+      const instance = ReactDOM.render(
+        <FixedSizeList
+          {...defaultProps}
+          initialScrollOffset={50}
+          overscanCount={3}
+          trailingOverscanCount={5}
+        />,
+        document.createElement('div')
+      );
+      simulateScroll(instance, 200);
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -59,7 +59,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeList overscanCount should accommodate a custom overscan 1`] = `
+exports[`FixedSizeList overscanCount and trailingOverscanCount should accommodate a custom overscan 1`] = `
 Array [
   Array [
     Object {
@@ -72,7 +72,83 @@ Array [
 ]
 `;
 
-exports[`FixedSizeList overscanCount should not scan past the beginning of the list 1`] = `
+exports[`FixedSizeList overscanCount and trailingOverscanCount should ignore "trailingOverscanCount" when not scrolling 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 1,
+      "overscanStopIndex": 11,
+      "visibleStartIndex": 4,
+      "visibleStopIndex": 8,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList overscanCount and trailingOverscanCount should overscan "overscanCount" in the direction being scrolled and "trailingOverscanCount" in the opposite direction 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 11,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 6,
+      "overscanStopIndex": 17,
+      "visibleStartIndex": 8,
+      "visibleStopIndex": 12,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 8,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList overscanCount and trailingOverscanCount should cap "trailingOverscanCount" to "overscanCount" 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 9,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 5,
+      "overscanStopIndex": 15,
+      "visibleStartIndex": 8,
+      "visibleStopIndex": 12,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList overscanCount and trailingOverscanCount should overscan in both directions when not scrolling 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 8,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList overscanCount and trailingOverscanCount should not scan past the beginning of the list 1`] = `
 Array [
   Array [
     Object {
@@ -85,7 +161,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeList overscanCount should not scan past the end of the list 1`] = `
+exports[`FixedSizeList overscanCount and trailingOverscanCount should not scan past the end of the list 1`] = `
 Array [
   Array [
     Object {
@@ -98,49 +174,7 @@ Array [
 ]
 `;
 
-exports[`FixedSizeList overscanCount should overscan in both directions when not scrolling 1`] = `
-Array [
-  Array [
-    Object {
-      "overscanStartIndex": 0,
-      "overscanStopIndex": 8,
-      "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
-    },
-  ],
-]
-`;
-
-exports[`FixedSizeList overscanCount should overscan in the direction being scrolled 1`] = `
-Array [
-  Array [
-    Object {
-      "overscanStartIndex": 0,
-      "overscanStopIndex": 8,
-      "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
-    },
-  ],
-  Array [
-    Object {
-      "overscanStartIndex": 3,
-      "overscanStopIndex": 10,
-      "visibleStartIndex": 4,
-      "visibleStopIndex": 8,
-    },
-  ],
-  Array [
-    Object {
-      "overscanStartIndex": 0,
-      "overscanStopIndex": 7,
-      "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
-    },
-  ],
-]
-`;
-
-exports[`FixedSizeList overscanCount should require a minimum of 1 overscan to support tabbing 1`] = `
+exports[`FixedSizeList overscanCount and trailingOverscanCount should require a minimum of 1 overscan to support tabbing 1`] = `
 Array [
   Array [
     Object {

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -58,6 +58,7 @@ export type Props<T> = {|
   outerElementType?: React$ElementType,
   outerTagName?: string, // deprecated
   overscanCount: number,
+  trailingOverscanCount: number,
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
@@ -149,6 +150,7 @@ export default function createListComponent({
       itemData: undefined,
       layout: 'vertical',
       overscanCount: 2,
+      trailingOverscanCount: 1,
       useIsScrolling: false,
     };
 
@@ -446,7 +448,7 @@ export default function createListComponent({
     _getItemStyleCache = memoizeOne((_: any, __: any, ___: any) => ({}));
 
     _getRangeToRender(): [number, number, number, number] {
-      const { itemCount, overscanCount } = this.props;
+      const { itemCount, overscanCount, trailingOverscanCount } = this.props;
       const { isScrolling, scrollDirection, scrollOffset } = this.state;
 
       if (itemCount === 0) {
@@ -465,16 +467,22 @@ export default function createListComponent({
         this._instanceProps
       );
 
+      // Do not allow trailing overscan larger than the forward overscan
+      // to avoid components being discarded when scrolling stops.
+      const trailingOverscanCountToUse = Math.min(
+        overscanCount,
+        trailingOverscanCount
+      );
       // Overscan by one item in each direction so that tab/focus works.
       // If there isn't at least one extra item, tab loops back around.
       const overscanBackward =
         !isScrolling || scrollDirection === 'backward'
           ? Math.max(1, overscanCount)
-          : 1;
+          : Math.max(1, trailingOverscanCountToUse);
       const overscanForward =
         !isScrolling || scrollDirection === 'forward'
           ? Math.max(1, overscanCount)
-          : 1;
+          : Math.max(1, trailingOverscanCountToUse);
 
       return [
         Math.max(0, startIndex - overscanBackward),

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -326,6 +326,38 @@ const PROPS = [
     type: 'number',
   },
   {
+    defaultValue: 1,
+    description: (
+      <Fragment>
+        <p>
+          The number of items (rows or columns) to render outside of the visible
+          area while scrolling. This applies to the opposite direction of scrolling,
+          which means that if you scroll downwards, it defines the number of items
+          to be rendered above the visible area, whereas <code>overscanCount</code> defines
+          the number of items to be rendered below the visible area.
+          This property can be important for two reasons:
+        </p>
+        <ul>
+          <li>
+            Overscanning by one row or column allows the tab key to focus on the
+            previous (not visible) item.
+          </li>
+          <li>
+            Overscanning slightly can reduce or prevent a flash of empty space
+            when a user changes the scrolling direction.
+          </li>
+        </ul>
+        <p>
+          Note that overscanning too much can negatively impact performance. By
+          default, List overscans by one item. To improve performance consider
+          using memoized components for each item renderer.
+        </p>
+      </Fragment>
+    ),
+    name: 'trailingOverscanCount',
+    type: 'number',
+  },
+  {
     defaultValue: null,
     description: (
       <p>


### PR DESCRIPTION
This pull-request implements the suggestion mentioned in this [issue comment](https://github.com/bvaughn/react-window/issues/111#issuecomment-460067279) regarding having `overscanCount` for the trailing/opposite/backwards side of the scrolling direction.

I have been using this library for the last couple of months successfully, but this limitation forced me to wrap this component into another one that basically handles the overscan in both sides and passes `overscanCount=1` to the `FixedSizeList` component. This however, led to some nasty hacks/workarounds for the scroll offset calculations, which do work, but it would be awesome if the library could support trailing overscan since it would simplify my usage of this component _a lot_.

I considered the following options while thinking how to best contribute the feature to `react-window`, but please let me know if you have a better approach in mind, or if you would like me to switch the implementation to one of the other options below.

1. Add `trailingOverscanCount` which is used only when scrolling, and applies on the opposite direction of scrolling. The value passed is independent of `overscanCount`. Defaults to 1 in order to keep the current functionality.
2. Add `trailingOverscanCount` which is used only when scrolling and applies on the opposite direction of scrolling. The value given is capped to `overscanCount` in order to avoid discarding the rendered components created during scroll when scrolling stops. For example, with option 1, when `overscanCount=2` and `trailingOverscanCount=10`, after a bit of scrolling, 8 components would be discarded when scrolling stops, whereas having this prop capped to `overscanCount` means that the rendered components will stay rendered once scrolling stops. Defaults to 1 in order to keep the current functionality.
2. Use the same `overscanCount` for the opposite direction as well. Easiest to implement but might not cover all the use-cases in case users want to have different values for each direction.

I decided to implement option 2, but happy to change it to any of the others if you prefer. For my use-case, all of the above options work so I am happy to contribute either of them.

This PR only contains changes to the List components, but once we (hopefully) agree on the implementation I can update the PR to contain changes in the Grid components as well. 

Thanks a lot for the great work, let me know if you see any major issue with the changes and if you have any alternative proposal.