### PR TITLE
Fixed a memory leak in `ItemMeasurer`

### DIFF
--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -96,6 +96,7 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
   componentWillUnmount() {
     if (this._resizeObserver !== null) {
       this._resizeObserver.disconnect();
+      this._resizeObserver = null;
     }
   }
 
@@ -141,8 +142,10 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     if (ref instanceof HTMLElement) {
       this._didProvideValidRef = true;
       this._node = ref;
-    } else if (ref !== null) {
+    } else if (ref) {
       this._node = ((findDOMNode(ref): any): HTMLElement);
+    } else {
+      this._node = null;
     }
 
     if (this._resizeObserver !== null && this._node !== null) {


### PR DESCRIPTION
Noticed memory was ballooning over time in an app I'm working on; fired up the Chromium profiler and took some heap dumps, noticed **tons**  of `ResizeObserver` references that were not eligible for GC. Eventually traced it back to this.

If the resulting ref was null in `_refSetter()`, the old reference wasn't getting reset, and we'd end up re-observing the original, stale node. This seems to have been preventing garbage collection.

After making this change, memory usage seems stable.