### PR TITLE
[Issue 244] List flickers on iOS during rubber band overscrolling

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -45,8 +45,8 @@ describe('FixedSizeList', () => {
     };
 
     // Test renders will set clientHeight and scrollHeight to zero
-    // so we need to manually mock the response of isVerticallyOverScolled.
-    domHelpers.isVerticallyOverScolled = () => false;
+    // so we need to manually mock the response of isVerticallyOverScrolled.
+    domHelpers.isVerticallyOverScrolled = () => false;
   });
 
   it('should render an empty list', () => {
@@ -558,8 +558,8 @@ describe('FixedSizeList', () => {
       expect(onScroll.mock.calls[0][0].scrollUpdateWasRequested).toBe(false);
     });
 
-    it('should not call onScroll if isVerticallyOverScolled', () => {
-      domHelpers.isVerticallyOverScolled = () => true;
+    it('should not call onScroll if isVerticallyOverScrolled', () => {
+      domHelpers.isVerticallyOverScrolled = () => true;
       const onScroll = jest.fn();
       // Use ReactDOM renderer so the container ref and "onScroll" event work correctly.
       const instance = ReactDOM.render(

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import ReactTestRenderer from 'react-test-renderer';
 import ReactTestUtils from 'react-dom/test-utils';
 import { FixedSizeList } from '..';
+import * as domHelpers from '../domHelpers';
 
 const simulateScroll = (instance, scrollOffset, direction = 'vertical') => {
   if (direction === 'horizontal') {
@@ -42,6 +43,10 @@ describe('FixedSizeList', () => {
       onItemsRendered,
       width: 50,
     };
+
+    // Test renders will set clientHeight and scrollHeight to zero
+    // so we need to manually mock the response of isVerticallyOverScolled.
+    domHelpers.isVerticallyOverScolled = () => false;
   });
 
   it('should render an empty list', () => {
@@ -551,6 +556,19 @@ describe('FixedSizeList', () => {
       onScroll.mockClear();
       simulateScroll(instance, 200);
       expect(onScroll.mock.calls[0][0].scrollUpdateWasRequested).toBe(false);
+    });
+
+    it('should not call onScroll if isVerticallyOverScolled', () => {
+      domHelpers.isVerticallyOverScolled = () => true;
+      const onScroll = jest.fn();
+      // Use ReactDOM renderer so the container ref and "onScroll" event work correctly.
+      const instance = ReactDOM.render(
+        <FixedSizeList {...defaultProps} onScroll={onScroll} />,
+        document.createElement('div')
+      );
+      onScroll.mockClear();
+      simulateScroll(instance, 200);
+      expect(onScroll).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/domHelpers.js
+++ b/src/__tests__/domHelpers.js
@@ -8,7 +8,7 @@ describe('isVerticallyOverScolled', () => {
     const isOverScolled = isVerticallyOverScolled({
       scrollTop: -1,
       clientHeight,
-      scrollHeight
+      scrollHeight,
     });
     expect(isOverScolled).toBe(true);
   });
@@ -17,25 +17,25 @@ describe('isVerticallyOverScolled', () => {
     const isOverScolled = isVerticallyOverScolled({
       scrollTop: 0,
       clientHeight,
-      scrollHeight
+      scrollHeight,
     });
     expect(isOverScolled).toBe(false);
   });
 
   it('returns not overscrolled when scrollTop is equal to scrollHeight minus clientHeight', () => {
     const isOverScolled = isVerticallyOverScolled({
-      scrollTop: (scrollHeight - clientHeight),
+      scrollTop: scrollHeight - clientHeight,
       clientHeight,
-      scrollHeight
+      scrollHeight,
     });
     expect(isOverScolled).toBe(false);
   });
 
   it('returns overscrolled when scrollTop is greater than scrollHeight minus clientHeight', () => {
     const isOverScolled = isVerticallyOverScolled({
-      scrollTop: (scrollHeight - clientHeight) + 1,
+      scrollTop: scrollHeight - clientHeight + 1,
       clientHeight,
-      scrollHeight
+      scrollHeight,
     });
     expect(isOverScolled).toBe(true);
   });

--- a/src/__tests__/domHelpers.js
+++ b/src/__tests__/domHelpers.js
@@ -1,11 +1,11 @@
-import { isVerticallyOverScolled } from '../domHelpers';
+import { isVerticallyOverScrolled } from '../domHelpers';
 
-describe('isVerticallyOverScolled', () => {
+describe('isVerticallyOverScrolled', () => {
   const clientHeight = 500;
   const scrollHeight = 1000;
 
   it('returns overscrolled when scrollTop is less than 0', () => {
-    const isOverScolled = isVerticallyOverScolled({
+    const isOverScolled = isVerticallyOverScrolled({
       scrollTop: -1,
       clientHeight,
       scrollHeight,
@@ -14,7 +14,7 @@ describe('isVerticallyOverScolled', () => {
   });
 
   it('returns not overscrolled when scrollTop is equal to 0', () => {
-    const isOverScolled = isVerticallyOverScolled({
+    const isOverScolled = isVerticallyOverScrolled({
       scrollTop: 0,
       clientHeight,
       scrollHeight,
@@ -23,7 +23,7 @@ describe('isVerticallyOverScolled', () => {
   });
 
   it('returns not overscrolled when scrollTop is equal to scrollHeight minus clientHeight', () => {
-    const isOverScolled = isVerticallyOverScolled({
+    const isOverScolled = isVerticallyOverScrolled({
       scrollTop: scrollHeight - clientHeight,
       clientHeight,
       scrollHeight,
@@ -32,7 +32,7 @@ describe('isVerticallyOverScolled', () => {
   });
 
   it('returns overscrolled when scrollTop is greater than scrollHeight minus clientHeight', () => {
-    const isOverScolled = isVerticallyOverScolled({
+    const isOverScolled = isVerticallyOverScrolled({
       scrollTop: scrollHeight - clientHeight + 1,
       clientHeight,
       scrollHeight,

--- a/src/__tests__/domHelpers.js
+++ b/src/__tests__/domHelpers.js
@@ -1,0 +1,42 @@
+import { isVerticallyOverScolled } from '../domHelpers';
+
+describe('isVerticallyOverScolled', () => {
+  const clientHeight = 500;
+  const scrollHeight = 1000;
+
+  it('returns overscrolled when scrollTop is less than 0', () => {
+    const isOverScolled = isVerticallyOverScolled({
+      scrollTop: -1,
+      clientHeight,
+      scrollHeight
+    });
+    expect(isOverScolled).toBe(true);
+  });
+
+  it('returns not overscrolled when scrollTop is equal to 0', () => {
+    const isOverScolled = isVerticallyOverScolled({
+      scrollTop: 0,
+      clientHeight,
+      scrollHeight
+    });
+    expect(isOverScolled).toBe(false);
+  });
+
+  it('returns not overscrolled when scrollTop is equal to scrollHeight minus clientHeight', () => {
+    const isOverScolled = isVerticallyOverScolled({
+      scrollTop: (scrollHeight - clientHeight),
+      clientHeight,
+      scrollHeight
+    });
+    expect(isOverScolled).toBe(false);
+  });
+
+  it('returns overscrolled when scrollTop is greater than scrollHeight minus clientHeight', () => {
+    const isOverScolled = isVerticallyOverScolled({
+      scrollTop: (scrollHeight - clientHeight) + 1,
+      clientHeight,
+      scrollHeight
+    });
+    expect(isOverScolled).toBe(true);
+  });
+});

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,7 +2,7 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
-import { isVerticallyOverScolled } from './domHelpers'
+import { isVerticallyOverScolled } from './domHelpers';
 import { cancelTimeout, requestTimeout } from './timer';
 
 import type { TimeoutID } from './timer';
@@ -533,7 +533,9 @@ export default function createListComponent({
         // On iOS, we can arrive at negative offsets by swiping past the
         // start or past the end which activates the rubber band overscrolling feature.
         // When this happens, we're scrolling outside the constraints and don't need rerenders.
-        if (isVerticallyOverScolled({ scrollTop, scrollHeight, clientHeight })) {
+        if (
+          isVerticallyOverScolled({ scrollTop, scrollHeight, clientHeight })
+        ) {
           return null;
         }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,7 +2,7 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
-import { isVerticallyOverScolled } from './domHelpers';
+import { isVerticallyOverScrolled } from './domHelpers';
 import { cancelTimeout, requestTimeout } from './timer';
 
 import type { TimeoutID } from './timer';
@@ -534,7 +534,7 @@ export default function createListComponent({
         // start or past the end which activates the rubber band overscrolling feature.
         // When this happens, we're scrolling outside the constraints and don't need rerenders.
         if (
-          isVerticallyOverScolled({ scrollTop, scrollHeight, clientHeight })
+          isVerticallyOverScrolled({ scrollTop, scrollHeight, clientHeight })
         ) {
           return null;
         }

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,6 +2,7 @@
 
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
+import { isVerticallyOverScolled } from './domHelpers'
 import { cancelTimeout, requestTimeout } from './timer';
 
 import type { TimeoutID } from './timer';
@@ -519,12 +520,20 @@ export default function createListComponent({
     };
 
     _onScrollVertical = (event: ScrollEvent): void => {
-      const { scrollTop } = event.currentTarget;
+      const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
+
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollTop) {
           // Scroll position may have been updated by cDM/cDU,
           // In which case we don't need to trigger another render,
           // And we don't want to update state.isScrolling.
+          return null;
+        }
+
+        // On iOS, we can arrive at negative offsets by swiping past the
+        // start or past the end which activates the rubber band overscrolling feature.
+        // When this happens, we're scrolling outside the constraints and don't need rerenders.
+        if (isVerticallyOverScolled({ scrollTop, scrollHeight, clientHeight })) {
           return null;
         }
 

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -36,7 +36,7 @@ type Props = {
   scrollTop: number,
 };
 
-export function isVerticallyOverScolled({
+export function isVerticallyOverScrolled({
   clientHeight,
   scrollHeight,
   scrollTop,

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -30,7 +30,18 @@ export function getScrollbarSize(recalculate?: boolean = false): number {
 //
 // MDN determine if an element has been totally scrolled:
 // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
-export const isVerticallyOverScolled = ({ scrollTop, scrollHeight, clientHeight }) => {
-  const isOverScrolled = (scrollTop < 0) || (scrollTop > (scrollHeight - clientHeight));
+type Props = {
+  clientHeight: number,
+  scrollHeight: number,
+  scrollTop: number,
+};
+
+export function isVerticallyOverScolled({
+  clientHeight,
+  scrollHeight,
+  scrollTop,
+}: Props): boolean {
+  const isOverScrolled =
+    scrollTop < 0 || scrollTop > scrollHeight - clientHeight;
   return isOverScrolled;
 }

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -20,3 +20,17 @@ export function getScrollbarSize(recalculate?: boolean = false): number {
 
   return size;
 }
+
+// Determines whether or not we have scrolled outside of the
+// container boundaries. This occurs frequently on iOS
+// with the rubber band overscrolling feature. This current
+// implementation is focused specifically on vertical scrolling
+// for Lists. A similar strategy for horizontal scrolling may
+// need extra consideration due to rtl vs ltr concerns.
+//
+// MDN determine if an element has been totally scrolled:
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#Problems_and_solutions
+export const isVerticallyOverScolled = ({ scrollTop, scrollHeight, clientHeight }) => {
+  const isOverScrolled = (scrollTop < 0) || (scrollTop > (scrollHeight - clientHeight));
+  return isOverScrolled;
+}


### PR DESCRIPTION
Added logic to determine whether or not we have overscrolled
vertical scrolling boundaries of list.

Updated list vertical scrolling handler to skip rerenders
if we have overscrolled.