### PR TITLE
Add support for RTL in Edge

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -368,7 +368,7 @@ export default function createGridComponent({
             case 'negative':
               outerRef.scrollLeft = -scrollLeft;
               break;
-            case 'reverse':
+            case 'positive-ascending':
               outerRef.scrollLeft = scrollLeft;
               break;
             default:
@@ -757,7 +757,7 @@ export default function createGridComponent({
             case 'negative':
               calculatedScrollLeft = -scrollLeft;
               break;
-            case 'default':
+            case 'positive-descending':
               calculatedScrollLeft = scrollWidth - clientWidth - scrollLeft;
               break;
           }

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -3,7 +3,7 @@
 import memoizeOne from 'memoize-one';
 import { createElement, PureComponent } from 'react';
 import { cancelTimeout, requestTimeout } from './timer';
-import { isRTLOffsetNegative } from './domHelpers';
+import { getRTLOffsetType } from './domHelpers';
 
 import type { TimeoutID } from './timer';
 
@@ -251,18 +251,24 @@ export default function createListComponent({
 
       if (scrollUpdateWasRequested && this._outerRef != null) {
         const outerRef = ((this._outerRef: any): HTMLElement);
+
         // TODO Deprecate direction "horizontal"
         if (direction === 'horizontal' || layout === 'horizontal') {
           if (direction === 'rtl') {
             // TRICKY According to the spec, scrollLeft should be negative for RTL aligned elements.
             // This is not the case for all browsers though (e.g. Chrome reports values as positive, measured relative to the left).
             // So we need to determine which browser behavior we're dealing with, and mimic it.
-            const isNegative = isRTLOffsetNegative();
-            if (isNegative) {
-              outerRef.scrollLeft = -scrollOffset;
-            } else {
-              const { clientWidth, scrollWidth } = outerRef;
-              outerRef.scrollLeft = scrollWidth - clientWidth - scrollOffset;
+            switch (getRTLOffsetType()) {
+              case 'negative':
+                outerRef.scrollLeft = -scrollOffset;
+                break;
+              case 'reverse':
+                outerRef.scrollLeft = scrollOffset;
+                break;
+              default:
+                const { clientWidth, scrollWidth } = outerRef;
+                outerRef.scrollLeft = scrollWidth - clientWidth - scrollOffset;
+                break;
             }
           } else {
             outerRef.scrollLeft = scrollOffset;
@@ -528,16 +534,17 @@ export default function createListComponent({
 
         let scrollOffset = scrollLeft;
         if (direction === 'rtl') {
-          const isNegative = isRTLOffsetNegative();
-
           // TRICKY According to the spec, scrollLeft should be negative for RTL aligned elements.
           // This is not the case for all browsers though (e.g. Chrome reports values as positive, measured relative to the left).
           // It's also easier for this component if we convert offsets to the same format as they would be in for ltr.
           // So the simplest solution is to determine which browser behavior we're dealing with, and convert based on it.
-          if (isNegative) {
-            scrollOffset = -scrollLeft;
-          } else {
-            scrollOffset = scrollWidth - clientWidth - scrollLeft;
+          switch (getRTLOffsetType()) {
+            case 'negative':
+              scrollOffset = -scrollLeft;
+              break;
+            case 'default':
+              scrollOffset = scrollWidth - clientWidth - scrollLeft;
+              break;
           }
         }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -262,7 +262,7 @@ export default function createListComponent({
               case 'negative':
                 outerRef.scrollLeft = -scrollOffset;
                 break;
-              case 'reverse':
+              case 'positive-ascending':
                 outerRef.scrollLeft = scrollOffset;
                 break;
               default:
@@ -542,7 +542,7 @@ export default function createListComponent({
             case 'negative':
               scrollOffset = -scrollLeft;
               break;
-            case 'default':
+            case 'positive-descending':
               scrollOffset = scrollWidth - clientWidth - scrollLeft;
               break;
           }

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -21,7 +21,10 @@ export function getScrollbarSize(recalculate?: boolean = false): number {
   return size;
 }
 
-export type RTLOffsetType = 'default' | 'negative' | 'reverse';
+export type RTLOffsetType =
+  | 'negative'
+  | 'positive-descending'
+  | 'positive-ascending';
 
 let cachedRTLResult: RTLOffsetType | null = null;
 
@@ -50,13 +53,13 @@ export function getRTLOffsetType(recalculate?: boolean = false): RTLOffsetType {
     ((document.body: any): HTMLBodyElement).appendChild(outerDiv);
 
     if (outerDiv.scrollLeft > 0) {
-      cachedRTLResult = 'default';
+      cachedRTLResult = 'positive-descending';
     } else {
       outerDiv.scrollLeft = 1;
       if (outerDiv.scrollLeft === 0) {
         cachedRTLResult = 'negative';
       } else {
-        cachedRTLResult = 'reverse';
+        cachedRTLResult = 'positive-ascending';
       }
     }
 

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -21,7 +21,9 @@ export function getScrollbarSize(recalculate?: boolean = false): number {
   return size;
 }
 
-let cachedRTLResult: boolean | null = null;
+export type RTLOffsetType = 'default' | 'negative' | 'reverse';
+
+let cachedRTLResult: RTLOffsetType | null = null;
 
 // TRICKY According to the spec, scrollLeft should be negative for RTL aligned elements.
 // Chrome does not seem to adhere; its scrollLeft values are positive (measured relative to the left).
@@ -29,7 +31,7 @@ let cachedRTLResult: boolean | null = null;
 // The safest way to check this is to intentionally set a negative offset,
 // and then verify that the subsequent "scroll" event matches the negative offset.
 // If it does not match, then we can assume a non-standard RTL scroll implementation.
-export function isRTLOffsetNegative(recalculate?: boolean = false): boolean {
+export function getRTLOffsetType(recalculate?: boolean = false): RTLOffsetType {
   if (cachedRTLResult === null || recalculate) {
     const outerDiv = document.createElement('div');
     const outerStyle = outerDiv.style;
@@ -47,8 +49,16 @@ export function isRTLOffsetNegative(recalculate?: boolean = false): boolean {
 
     ((document.body: any): HTMLBodyElement).appendChild(outerDiv);
 
-    outerDiv.scrollLeft = -10;
-    cachedRTLResult = outerDiv.scrollLeft === -10;
+    if (outerDiv.scrollLeft > 0) {
+      cachedRTLResult = 'default';
+    } else {
+      outerDiv.scrollLeft = 1;
+      if (outerDiv.scrollLeft === 0) {
+        cachedRTLResult = 'negative';
+      } else {
+        cachedRTLResult = 'reverse';
+      }
+    }
 
     ((document.body: any): HTMLBodyElement).removeChild(outerDiv);
 


### PR DESCRIPTION
For #159 

This fix adds support for non-bleeding edge Edge which uses a different positive scrollLeft when in RTL compared to the positive scrollLeft that Chrome uses.