### PR TITLE
FixedSizeList fixes for onItemsRendered & partially-visible items

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -77,7 +77,7 @@ describe('FixedSizeList', () => {
 
   it('should render a list of rows', () => {
     ReactTestRenderer.create(<FixedSizeList {...defaultProps} />);
-    expect(itemRenderer).toHaveBeenCalledTimes(7);
+    expect(itemRenderer).toHaveBeenCalledTimes(6);
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
@@ -85,7 +85,7 @@ describe('FixedSizeList', () => {
     ReactTestRenderer.create(
       <FixedSizeList {...defaultProps} layout="horizontal" />
     );
-    expect(itemRenderer).toHaveBeenCalledTimes(5);
+    expect(itemRenderer).toHaveBeenCalledTimes(4);
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
@@ -421,10 +421,56 @@ describe('FixedSizeList', () => {
       // Scroll down enough to show item 10 at the bottom.
       rendered.getInstance().scrollToItem(10, 'auto');
       // No need to scroll again; item 9 is already visible.
-      // Overscan indices will change though, since direction changes.
+      // Because there's no scrolling, it won't call onItemsRendered.
       rendered.getInstance().scrollToItem(9, 'auto');
       // Scroll up enough to show item 2 at the top.
       rendered.getInstance().scrollToItem(2, 'auto');
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('scroll with align = "auto" should work with partially-visible items', () => {
+      const rendered = ReactTestRenderer.create(
+        // Create list where items don't fit exactly into container.
+        // The container has space for 3 1/3 items.
+        <FixedSizeList {...defaultProps} itemSize={30} />
+      );
+      // Scroll down enough to show item 10 at the bottom.
+      // Should show 4 items: 3 full and one partial at the end
+      rendered.getInstance().scrollToItem(10, 'auto');
+      // No need to scroll again; item 9 is already visible.
+      // Because there's no scrolling, it won't call onItemsRendered.
+      rendered.getInstance().scrollToItem(9, 'auto');
+      // Scroll to near the end. #96 will be shown as partial.
+      rendered.getInstance().scrollToItem(99, 'auto');
+      // Scroll back to show #96 fully. This will cause #99 to be shown as a
+      // partial. Because #96 was already shown previously as a partial, all
+      // props of the onItemsRendered will be the same. This means that even
+      // though a scroll happened in the DOM, the onItemsRendered event is
+      // not triggered. IMHO this is probably a bug, but it's one we can fix
+      // later via a separate PR.
+      rendered.getInstance().scrollToItem(96, 'auto');
+      // Scroll forward again. Because item #99 was already shown partially,
+      // all props of the onItemsRendered will be the same.
+      rendered.getInstance().scrollToItem(99, 'auto');
+      // Scroll to the second item. A partial fifth item should
+      // be shown after it.
+      rendered.getInstance().scrollToItem(1, 'auto');
+      // Scroll to the first item. Now the fourth item should be a partial.
+      rendered.getInstance().scrollToItem(0, 'auto');
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
+    });
+
+    it('scroll with align = "auto" should work with very small lists and partial items', () => {
+      const rendered = ReactTestRenderer.create(
+        // Create list with only two items, one of which will be shown as a partial.
+        <FixedSizeList {...defaultProps} itemSize={60} itemCount={2} />
+      );
+      // Show the second item fully. The first item should be a partial.
+      rendered.getInstance().scrollToItem(1, 'auto');
+      // Go back to the first item. The second should be a partial again.
+      rendered.getInstance().scrollToItem(0, 'auto');
+      // None of the scrollToItem calls above should actually cause a scroll,
+      // so there will only be one snapshot.
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
 
@@ -576,6 +622,29 @@ describe('FixedSizeList', () => {
       onScroll.mockClear();
       simulateScroll(instance, 200);
       expect(onScroll.mock.calls[0][0].scrollUpdateWasRequested).toBe(false);
+    });
+
+    it('scrolling should report partial items correctly in onItemsRendered', () => {
+      // Use ReactDOM renderer so the container ref works correctly.
+      const instance = ReactDOM.render(
+        <FixedSizeList {...defaultProps} initialScrollOffset={20} />,
+        document.createElement('div')
+      );
+      // Scroll 2 items fwd, but thanks to the initialScrollOffset, we should
+      // still be showing partials on both ends.
+      simulateScroll(instance, 70);
+      // Scroll a little fwd to cause partials to be hidden
+      simulateScroll(instance, 75);
+      // Scroll backwards to show partials again
+      simulateScroll(instance, 70);
+      // Scroll near the end so that the last item is shown
+      // as a partial.
+      simulateScroll(instance, 96 * 25 - 5);
+      // Scroll to the end. No partials.
+      simulateScroll(instance, 96 * 25);
+      // Verify that backwards scrolling near the end works OK.
+      simulateScroll(instance, 96 * 25 - 5);
+      expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
   });
 

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -5,17 +5,17 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 4,
+      "overscanStopIndex": 3,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 2,
+      "visibleStopIndex": 1,
     },
   ],
 ]
@@ -64,9 +64,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 1,
-      "overscanStopIndex": 11,
+      "overscanStopIndex": 10,
       "visibleStartIndex": 4,
-      "visibleStopIndex": 8,
+      "visibleStopIndex": 7,
     },
   ],
 ]
@@ -77,9 +77,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
 ]
@@ -103,9 +103,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 8,
+      "overscanStopIndex": 7,
       "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "visibleStopIndex": 5,
     },
   ],
 ]
@@ -116,25 +116,25 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 8,
+      "overscanStopIndex": 7,
       "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "visibleStopIndex": 5,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 3,
-      "overscanStopIndex": 10,
+      "overscanStopIndex": 9,
       "visibleStartIndex": 4,
-      "visibleStopIndex": 8,
+      "visibleStopIndex": 7,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 7,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "visibleStopIndex": 5,
     },
   ],
 ]
@@ -145,9 +145,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 1,
-      "overscanStopIndex": 7,
+      "overscanStopIndex": 6,
       "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "visibleStopIndex": 5,
     },
   ],
 ]
@@ -171,9 +171,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
 ]
@@ -186,25 +186,25 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 5,
-      "overscanStopIndex": 13,
+      "overscanStopIndex": 12,
       "visibleStartIndex": 7,
-      "visibleStopIndex": 11,
+      "visibleStopIndex": 10,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 8,
+      "overscanStopIndex": 7,
       "visibleStartIndex": 2,
-      "visibleStopIndex": 6,
+      "visibleStopIndex": 5,
     },
   ],
 ]
@@ -215,9 +215,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
@@ -239,9 +239,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
@@ -260,33 +260,33 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 5,
-      "overscanStopIndex": 13,
-      "visibleStartIndex": 7,
-      "visibleStopIndex": 11,
-    },
-  ],
-  Array [
-    Object {
-      "overscanStartIndex": 4,
       "overscanStopIndex": 12,
-      "visibleStartIndex": 6,
+      "visibleStartIndex": 7,
       "visibleStopIndex": 10,
     },
   ],
   Array [
     Object {
+      "overscanStartIndex": 4,
+      "overscanStopIndex": 11,
+      "visibleStartIndex": 6,
+      "visibleStopIndex": 9,
+    },
+  ],
+  Array [
+    Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
 ]
@@ -297,9 +297,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
@@ -313,17 +313,17 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 4,
-      "overscanStopIndex": 12,
+      "overscanStopIndex": 11,
       "visibleStartIndex": 6,
-      "visibleStopIndex": 10,
+      "visibleStopIndex": 9,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
@@ -339,7 +339,7 @@ Array [
       "overscanStartIndex": 93,
       "overscanStopIndex": 99,
       "visibleStartIndex": 95,
-      "visibleStopIndex": 99,
+      "visibleStopIndex": 98,
     },
   ],
   Array [
@@ -355,7 +355,7 @@ Array [
       "overscanStartIndex": 92,
       "overscanStopIndex": 99,
       "visibleStartIndex": 94,
-      "visibleStopIndex": 98,
+      "visibleStopIndex": 97,
     },
   ],
   Array [
@@ -390,25 +390,25 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 8,
-      "overscanStopIndex": 16,
+      "overscanStopIndex": 15,
       "visibleStartIndex": 10,
-      "visibleStopIndex": 14,
+      "visibleStopIndex": 13,
     },
   ],
   Array [
     Object {
       "overscanStartIndex": 7,
-      "overscanStopIndex": 15,
+      "overscanStopIndex": 14,
       "visibleStartIndex": 9,
-      "visibleStopIndex": 13,
+      "visibleStopIndex": 12,
     },
   ],
   Array [
@@ -427,9 +427,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 4,
+      "overscanStopIndex": 3,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 2,
+      "visibleStopIndex": 1,
     },
   ],
 ]
@@ -440,9 +440,128 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList scrollToItem method scroll with align = "auto" should work with partially-visible items 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 6,
+      "overscanStopIndex": 13,
+      "visibleStartIndex": 8,
+      "visibleStopIndex": 11,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 6,
+      "visibleStartIndex": 1,
+      "visibleStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList scrollToItem method scroll with align = "auto" should work with very small lists and partial items 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 1,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 1,
+    },
+  ],
+]
+`;
+
+exports[`FixedSizeList onScroll scrolling should report partial items correctly in onItemsRendered 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
       "overscanStopIndex": 6,
       "visibleStartIndex": 0,
       "visibleStopIndex": 4,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 1,
+      "overscanStopIndex": 8,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 2,
+      "overscanStopIndex": 8,
+      "visibleStartIndex": 3,
+      "visibleStopIndex": 6,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 7,
+      "visibleStartIndex": 2,
+      "visibleStopIndex": 6,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 94,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 95,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 95,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 96,
+      "visibleStopIndex": 99,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 93,
+      "overscanStopIndex": 99,
+      "visibleStartIndex": 95,
+      "visibleStopIndex": 99,
     },
   ],
 ]

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -239,7 +239,12 @@ const PROPS = [
         <p>
           This callback will only be called when item indices change. It will
           not be called if items are re-rendered for other reasons (e.g. a
-          change in <code>isScrolling</code> or <code>data</code> params).
+          change in <code>isScrolling</code> or <code>data</code> params). The
+          <code>visibleStartIndex</code> and <code>visibleStopIndex</code>
+          parameters are the first and last index currently visible, including
+          items that are partially visible. Note that scrolling a
+          partially-visible item into full visibility will not trigger this
+          callback because the item indices won't change.
         </p>
         <div className={styles.CodeBlockWrapper}>
           <CodeBlock value={CODE_ON_ITEMS_RENDERED} />
@@ -299,7 +304,7 @@ const PROPS = [
     type: 'string',
   },
   {
-    defaultValue: 1,
+    defaultValue: 2,
     description: (
       <Fragment>
         <p>
@@ -317,8 +322,11 @@ const PROPS = [
           </li>
         </ul>
         <p>
-          Note that overscanning too much can negatively impact performance. By
-          default, List overscans by one item.
+          Note that overscanning too much can negatively impact performance. To
+          support tabbing and accessibility, List will overscan at least one
+          item, even if this value is set to zero. When items are partially
+          visible at the start and/or end of the viewport, overscanning starts
+          after the partially visible items.
         </p>
       </Fragment>
     ),
@@ -401,13 +409,16 @@ const METHODS = [
         <ul>
           <li>
             auto (default) - Scroll as little as possible to ensure the item is
-            visible. (If the item is already visible, it won't scroll at all.)
+            fully visible. If the item is already fully visible, it won't scroll
+            at all. If items don't fit into the viewport evenly, then the
+            partial item will be shown at the end, except if the last item is
+            visible and the partial item is shown at the start of the viewport.
           </li>
           <li>
-            smart - If the item is already visible, don't scroll at all. If it
-            is less than one viewport away, scroll as little as possible so that
-            it becomes visible. If it is more than one viewport away, scroll so
-            that it is centered within the list.
+            smart - If the item is already fully visible, don't scroll at all.
+            If it's less than one viewport away, scroll as little as possible so
+            that it becomes visible. If it is more than one viewport away,
+            scroll so that it is centered within the list.
           </li>
           <li>center - Center align the item within the list.</li>
           <li>


### PR DESCRIPTION
This PR fixes a few related issues with `FixedSizeList`:
* Updates test snapshots to correctly calculate expected item indices for all `onItemsRendered` calls for `FixedSizeList`.  This was done with pen-and-paper and manual calculation to ensure that the existing implementation didn't influence expected results. Most of the changes involved reducing  `visibleStopIndex` and `overscanStopIndex` by one index because of #270.
* Adds tests for partially-visible items, which exposed a few more bugs beyond #270.
* Reports `visibleStopIndex` is correctly in `onItemsRendered`. Previously, `visibleStopIndex` was one item higher than the last visible index.  Fixes #270.
* Ensures that partially-visible items are correctly handled in `onItemsRendered` and `scrollToItem`.
* Fixes the `align: 'center'` option of `scrollToItem` in cases where the viewport is near the beginning or end of the list where the existing method of calculating the centered offset (averaging `minOffset` and `maxOffset`) didn't produce a correct result.
* Changes the behavior of the `align: 'auto'` option of `scrollToItem` to handle the case where items don't fit evenly in the viewport. Now, when scrolling forward the partially-visible item will always be shown hanging off the end of the viewport. Exception: at the end of the list, there's no room to show the partial at the end of the viewport so it's shown at the beginning instead. Previously, forward scrolls would hang the partial item off the top of the viewport, which IMHO looked really weird when there wasn't an obvious reason for the visual weirdness (like being at the end of the list). Note that partially-visible items were broken in several ways previously, so I don't think this is a breaking change-- because no one could have used the current implementation successfully with `size % itemSize !== 0`.  Also note that this change doesn't affect backwards scrolls because the partial (if any) was already shown at the bottom when scrolling up in the current implementation.
* Updates the docs with notes relating to the changes above. 
* Updates the docs for `overscanCount` to show a default value of `2` (which matches react-window's source code). Previously, the default value shown was `1` which didn't match the code.  We could go the other way and change the default in the code to match the docs (which would make the default faster!) but I'd worry about making this change without an explicit breaking change because it would affect user-visible behavior during fast scrolls. 
* In `getOffsetForIndexAndAlignment`, simplified the conditional `scrollOffset - minOffset < maxOffset - scrollOffset` to `scrollOffset < minOffset` which returns equivalent results in that context but is more readable. 

In theory there is a breaking change in this PR: fixing `visibleStopIndex`/`overscanStopIndex` may break clients who are depending on the broken behavior, e.g. if they assume that the `*StopIndex` values were supposed to be exclusive.  @bvaughn - I dunno if this is worth a major version bump or not.

Note that this PR only fixes `FixedSizeList`. Looking at the source for `VariableSizeList` and the `*Grid` components, it's likely that they share many of the same issues.  In a perfect world I'd have fixed those too, but this PR took more time than I expected so I didn't have time to fix other components. Hopefully someone can use changes in this PR as inspiration for fixing those other components too!
