### PR TITLE
Add source maps for debugging

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,12 +15,14 @@ export default [
     output: {
       file: pkg.main,
       format: 'cjs',
+      sourcemap: true,
     },
     external,
     plugins: [
       babel({
         runtimeHelpers: true,
         plugins: ['@babel/transform-runtime'],
+        sourceMaps: true,
       }),
       nodeResolve(),
       commonjs(),
@@ -32,12 +34,14 @@ export default [
     output: {
       file: pkg.module,
       format: 'esm',
+      sourcemap: true,
     },
     external,
     plugins: [
       babel({
         runtimeHelpers: true,
         plugins: [['@babel/transform-runtime', { useESModules: true }]],
+        sourceMaps: true,
       }),
       nodeResolve(),
       commonjs(),


### PR DESCRIPTION
Currently, the only way to debug into react-window source at runtime is via the transpiled code. This is unnecessarily painful, esp. for newbies. 

This PR enables sourcemaps for the react-window library, which enables users of the debugger in Chrome Dev Tools or IDEs like VSCode to step into the original source of react-window and to set breakpoints inside react-window's original source code. 

I tested the revised rollup config in VSCode and Chrome Dev Tools. In both debuggers, I was able to successfully able to step into react-window's original source and set breakpoints in react-window's original source. 

This PR adds one 37-character line to uncompressed bundle sizes (for the sourcemap comment at the end of the bundle file) but otherwise doesn't change runtime size or behavior.  Builds are about 300 msecs longer on my MacBook Pro with sourcemaps enabled, which I assume isn't a problem.