### PR TITLE
Fix umd global for react-dom

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ const babelConfigEsModules = babel({
 
 const umdGlobals = {
   react: 'React',
+  'react-dom': 'ReactDOM',
 };
 
 export default [


### PR DESCRIPTION
Before:
![Screen Shot 2019-07-09 at 1 23 33 PM](https://user-images.githubusercontent.com/3527892/60852775-3eb8f100-a24d-11e9-8c7a-b36489d728bf.png)

After:
![Screen Shot 2019-07-09 at 1 24 55 PM](https://user-images.githubusercontent.com/3527892/60852788-52645780-a24d-11e9-8b1c-1701c6da5abf.png)

Issue is not on master branch as that doesn't appear to be using 
`import { findDOMNode } from 'react-dom';`