### PR TITLE
pass start and end indexes to outer element

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -50,6 +50,10 @@ type OuterProps = {|
   children: React$Node,
   className: string | void,
   onScroll: ScrollEvent => void,
+  columnStartIndex: number,
+  columnStopIndex: number,
+  rowStartIndex: number,
+  rowStopIndex: number,
   style: {
     [string]: mixed,
   },
@@ -462,6 +466,10 @@ export default function createGridComponent({
           className,
           onScroll: this._onScroll,
           ref: this._outerRefSetter,
+          columnStartIndex,
+          columnStopIndex,
+          rowStartIndex,
+          rowStopIndex,
           style: {
             position: 'relative',
             height,


### PR DESCRIPTION
Hello there!

I've implemented sticky columns and rows in an alternative way by filtering these columns/rows out and rendering them in the outer element instead with `position: sticky;`.
At this point it's working just fine but they are not windowed, all of the sticky cells are rendered. To achieve windowing I need to pass `columnStartIndex`, `columnStopIndex`, `rowStartIndex`, `rowStopIndex` to outer element which I did with my pull request. It doesn't produce any additional renders because at the point where these values may change, other props on outer element would change also.

I attach a rough demo of my implementation of the grid as well as a code playground for this POC for reference. The indexes would be used in `StickyCells` component and they would be implemented as just a simple `if` conditional for the cells.

Let me know what you think, thanks!

demo: https://1r94e.csb.app/
sandbox: https://codesandbox.io/embed/jovial-monad-1r94e