### PR TITLE
Declared package side effects free

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "files": ["dist", "src/*.js"],
+  "sideEffects": false,
   "scripts": {
     "flow": "flow check --max-warnings=0 src && flow check website",
     "precommit": "lint-staged",


### PR DESCRIPTION
This sets the package.json field sideEffects to false. This allows for better tree shaking by downstream consumers, see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free for more information.

I skimmed over all included files and I did not see anything that would count following webpack's definition of tree shaking during a production build.

There is one side effect, but I believe its only used in development builds, so it would be okay to tree shake:
 - https://github.com/bvaughn/react-window/blob/master/src/createListComponent.js#L127-L136

For more details on how this field works and why it matter see the discussions here:
- https://github.com/FezVrasta/popper.js/pull/830
- https://github.com/react-dnd/react-dnd/pull/1577