### PR TITLE
Fixes issues in multi-window environment

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -195,6 +195,7 @@ export default function createGridComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
     _outerRef: ?HTMLDivElement;
+    _window: ?any;
 
     static defaultProps = {
       direction: 'ltr',
@@ -340,6 +341,7 @@ export default function createGridComponent({
 
     componentDidMount() {
       const { initialScrollLeft, initialScrollTop } = this.props;
+      this._window = window;
 
       if (this._outerRef != null) {
         const outerRef = ((this._outerRef: any): HTMLElement);
@@ -348,6 +350,10 @@ export default function createGridComponent({
         }
         if (typeof initialScrollTop === 'number') {
           outerRef.scrollTop = initialScrollTop;
+        }
+
+        if (this._outerRef.parentNode && this._outerRef.parentNode.ownerDocument && this._outerRef.parentNode.ownerDocument.defaultView) {
+          this._window = this._outerRef.parentNode.ownerDocument.defaultView;
         }
       }
 
@@ -388,7 +394,7 @@ export default function createGridComponent({
 
     componentWillUnmount() {
       if (this._resetIsScrollingTimeoutId !== null) {
-        cancelTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId, this._window);
       }
     }
 
@@ -807,12 +813,13 @@ export default function createGridComponent({
 
     _resetIsScrollingDebounced = () => {
       if (this._resetIsScrollingTimeoutId !== null) {
-        cancelTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId, this._window);
       }
 
       this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
-        IS_SCROLLING_DEBOUNCE_INTERVAL
+        IS_SCROLLING_DEBOUNCE_INTERVAL,
+        this._window
       );
     };
 

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -352,7 +352,11 @@ export default function createGridComponent({
           outerRef.scrollTop = initialScrollTop;
         }
 
-        if (this._outerRef.parentNode && this._outerRef.parentNode.ownerDocument && this._outerRef.parentNode.ownerDocument.defaultView) {
+        if (
+          this._outerRef.parentNode &&
+          this._outerRef.parentNode.ownerDocument &&
+          this._outerRef.parentNode.ownerDocument.defaultView
+        ) {
           this._window = this._outerRef.parentNode.ownerDocument.defaultView;
         }
       }

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -287,7 +287,7 @@ export default function createGridComponent({
     }): void {
       const { columnCount, height, rowCount, width } = this.props;
       const { scrollLeft, scrollTop } = this.state;
-      const scrollbarSize = getScrollbarSize();
+      const scrollbarSize = getScrollbarSize(false, this._window);
 
       if (columnIndex !== undefined) {
         columnIndex = Math.max(0, Math.min(columnIndex, columnCount - 1));
@@ -374,7 +374,7 @@ export default function createGridComponent({
         // So we need to determine which browser behavior we're dealing with, and mimic it.
         const outerRef = ((this._outerRef: any): HTMLElement);
         if (direction === 'rtl') {
-          switch (getRTLOffsetType()) {
+          switch (getRTLOffsetType(false, this._window)) {
             case 'negative':
               outerRef.scrollLeft = -scrollLeft;
               break;
@@ -766,7 +766,7 @@ export default function createGridComponent({
         // So the simplest solution is to determine which browser behavior we're dealing with, and convert based on it.
         let calculatedScrollLeft = scrollLeft;
         if (direction === 'rtl') {
-          switch (getRTLOffsetType()) {
+          switch (getRTLOffsetType(false, this._window)) {
             case 'negative':
               calculatedScrollLeft = -scrollLeft;
               break;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -269,7 +269,7 @@ export default function createListComponent({
             // TRICKY According to the spec, scrollLeft should be negative for RTL aligned elements.
             // This is not the case for all browsers though (e.g. Chrome reports values as positive, measured relative to the left).
             // So we need to determine which browser behavior we're dealing with, and mimic it.
-            switch (getRTLOffsetType()) {
+            switch (getRTLOffsetType(false, this._window)) {
               case 'negative':
                 outerRef.scrollLeft = -scrollOffset;
                 break;
@@ -552,7 +552,7 @@ export default function createListComponent({
           // This is not the case for all browsers though (e.g. Chrome reports values as positive, measured relative to the left).
           // It's also easier for this component if we convert offsets to the same format as they would be in for ltr.
           // So the simplest solution is to determine which browser behavior we're dealing with, and convert based on it.
-          switch (getRTLOffsetType()) {
+          switch (getRTLOffsetType(false, this._window)) {
             case 'negative':
               scrollOffset = -scrollLeft;
               break;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -160,6 +160,7 @@ export default function createListComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
+    _window: ?any;
 
     static defaultProps = {
       direction: 'ltr',
@@ -242,6 +243,11 @@ export default function createListComponent({
         }
       }
 
+      this._window = window;
+      if (this._outerRef != null && this._outerRef.parentNode && this._outerRef.parentNode.ownerDocument && this._outerRef.parentNode.ownerDocument.defaultView) {
+        this._window = this._outerRef.parentNode.ownerDocument.defaultView;
+      }
+
       this._callPropsCallbacks();
     }
 
@@ -283,7 +289,7 @@ export default function createListComponent({
 
     componentWillUnmount() {
       if (this._resetIsScrollingTimeoutId !== null) {
-        cancelTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId, this._window);
       }
     }
 
@@ -611,12 +617,13 @@ export default function createListComponent({
 
     _resetIsScrollingDebounced = () => {
       if (this._resetIsScrollingTimeoutId !== null) {
-        cancelTimeout(this._resetIsScrollingTimeoutId);
+        cancelTimeout(this._resetIsScrollingTimeoutId, this._window);
       }
 
       this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
-        IS_SCROLLING_DEBOUNCE_INTERVAL
+        IS_SCROLLING_DEBOUNCE_INTERVAL,
+        this._window
       );
     };
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -244,7 +244,12 @@ export default function createListComponent({
       }
 
       this._window = window;
-      if (this._outerRef != null && this._outerRef.parentNode && this._outerRef.parentNode.ownerDocument && this._outerRef.parentNode.ownerDocument.defaultView) {
+      if (
+        this._outerRef != null &&
+        this._outerRef.parentNode &&
+        this._outerRef.parentNode.ownerDocument &&
+        this._outerRef.parentNode.ownerDocument.defaultView
+      ) {
         this._window = this._outerRef.parentNode.ownerDocument.defaultView;
       }
 

--- a/src/domHelpers.js
+++ b/src/domHelpers.js
@@ -3,19 +3,22 @@
 let size: number = -1;
 
 // This utility copied from "dom-helpers" package.
-export function getScrollbarSize(recalculate?: boolean = false): number {
+export function getScrollbarSize(
+  recalculate?: boolean = false,
+  hostWindow?: any = window
+): number {
   if (size === -1 || recalculate) {
-    const div = document.createElement('div');
+    const div = hostWindow.document.createElement('div');
     const style = div.style;
     style.width = '50px';
     style.height = '50px';
     style.overflow = 'scroll';
 
-    ((document.body: any): HTMLBodyElement).appendChild(div);
+    ((hostWindow.document.body: any): HTMLBodyElement).appendChild(div);
 
     size = div.offsetWidth - div.clientWidth;
 
-    ((document.body: any): HTMLBodyElement).removeChild(div);
+    ((hostWindow.document.body: any): HTMLBodyElement).removeChild(div);
   }
 
   return size;
@@ -34,23 +37,26 @@ let cachedRTLResult: RTLOffsetType | null = null;
 // The safest way to check this is to intentionally set a negative offset,
 // and then verify that the subsequent "scroll" event matches the negative offset.
 // If it does not match, then we can assume a non-standard RTL scroll implementation.
-export function getRTLOffsetType(recalculate?: boolean = false): RTLOffsetType {
+export function getRTLOffsetType(
+  recalculate?: boolean = false,
+  hostWindow: any = window
+): RTLOffsetType {
   if (cachedRTLResult === null || recalculate) {
-    const outerDiv = document.createElement('div');
+    const outerDiv = hostWindow.document.createElement('div');
     const outerStyle = outerDiv.style;
     outerStyle.width = '50px';
     outerStyle.height = '50px';
     outerStyle.overflow = 'scroll';
     outerStyle.direction = 'rtl';
 
-    const innerDiv = document.createElement('div');
+    const innerDiv = hostWindow.document.createElement('div');
     const innerStyle = innerDiv.style;
     innerStyle.width = '100px';
     innerStyle.height = '100px';
 
     outerDiv.appendChild(innerDiv);
 
-    ((document.body: any): HTMLBodyElement).appendChild(outerDiv);
+    ((hostWindow.document.body: any): HTMLBodyElement).appendChild(outerDiv);
 
     if (outerDiv.scrollLeft > 0) {
       cachedRTLResult = 'positive-descending';
@@ -63,7 +69,7 @@ export function getRTLOffsetType(recalculate?: boolean = false): RTLOffsetType {
       }
     }
 
-    ((document.body: any): HTMLBodyElement).removeChild(outerDiv);
+    ((hostWindow.document.body: any): HTMLBodyElement).removeChild(outerDiv);
 
     return cachedRTLResult;
   }

--- a/src/timer.js
+++ b/src/timer.js
@@ -18,7 +18,11 @@ export function cancelTimeout(timeoutID: TimeoutID, hostWindow: any) {
   hostWindow.cancelAnimationFrame(timeoutID.id);
 }
 
-export function requestTimeout(callback: Function, delay: number, hostWindow: any): TimeoutID {
+export function requestTimeout(
+  callback: Function,
+  delay: number,
+  hostWindow: any
+): TimeoutID {
   const start = now();
 
   function tick() {

--- a/src/timer.js
+++ b/src/timer.js
@@ -14,23 +14,23 @@ export type TimeoutID = {|
   id: AnimationFrameID,
 |};
 
-export function cancelTimeout(timeoutID: TimeoutID) {
-  cancelAnimationFrame(timeoutID.id);
+export function cancelTimeout(timeoutID: TimeoutID, hostWindow: any) {
+  hostWindow.cancelAnimationFrame(timeoutID.id);
 }
 
-export function requestTimeout(callback: Function, delay: number): TimeoutID {
+export function requestTimeout(callback: Function, delay: number, hostWindow: any): TimeoutID {
   const start = now();
 
   function tick() {
     if (now() - start >= delay) {
       callback.call(null);
     } else {
-      timeoutID.id = requestAnimationFrame(tick);
+      timeoutID.id = hostWindow.requestAnimationFrame(tick);
     }
   }
 
   const timeoutID: TimeoutID = {
-    id: requestAnimationFrame(tick),
+    id: hostWindow.requestAnimationFrame(tick),
   };
 
   return timeoutID;


### PR DESCRIPTION
When react-window is used in a multi-window environment, and React is running in the global/main window and renders to different child windows, react-window will not work as it should because it uses the global window and not the child window.

This PR fixes this issue by getting the current window from the `ref.parentNode.ownerDocument.defaultView` which has the proper reference to the current child window. If not we fallback to use the global window.