### PR TITLE
Browsers without native ResizeObservable are now still able to use DynamicSizeList

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-flow": "^7.0.0",
+    "@juggle/resize-observer": "^3.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^9.0.0",
     "babel-plugin-annotate-pure-calls": "^0.3.0",

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -87,7 +87,8 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     // This is necessary to support the DynamicSizeList layout logic.
     this._measureItem(true, true);
 
-    const Test = ResizeObserver || Polyfill;
+    const Test =
+      typeof ResizeObserver !== 'undefined' ? ResizeObserver : Polyfill;
     this._resizeObserver = new Test(this._onResize);
     if (this._node !== null) {
       this._resizeObserver.observe(this._node);

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -3,6 +3,8 @@
 import { cloneElement, Component } from 'react';
 import { findDOMNode } from 'react-dom';
 
+import { ResizeObserver as Polyfill } from '@juggle/resize-observer';
+
 import type { Direction, Layout } from './createListComponent';
 import type { HandleNewMeasurements } from './DynamicSizeList';
 
@@ -56,6 +58,8 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
   _resizeObserver: ResizeObserver | null = null;
 
   componentDidMount() {
+    console.log('SKDJHFJKS');
+    console.log(ResizeObserver);
     if (process.env.NODE_ENV !== 'production') {
       if (!this._didProvideValidRef) {
         const { item } = this.props;
@@ -83,14 +87,17 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     // This is necessary to support the DynamicSizeList layout logic.
     this._measureItem(true, true);
 
-    if (typeof ResizeObserver !== 'undefined') {
-      // Watch for resizes due to changed content,
-      // Or changes in the size of the parent container.
-      this._resizeObserver = new ResizeObserver(this._onResize);
-      if (this._node !== null) {
-        this._resizeObserver.observe(this._node);
-      }
+    const Test = ResizeObserver || Polyfill;
+    this._resizeObserver = new Test(this._onResize);
+    if (this._node !== null) {
+      this._resizeObserver.observe(this._node);
     }
+    // if (typeof ResizeObserver !== 'undefined') {
+    //   // Watch for resizes due to changed content,
+    //   // Or changes in the size of the parent container.
+    //
+    //
+    // }
   }
 
   componentWillUnmount() {

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -58,8 +58,6 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
   _resizeObserver: ResizeObserver | null = null;
 
   componentDidMount() {
-    console.log('SKDJHFJKS');
-    console.log(ResizeObserver);
     if (process.env.NODE_ENV !== 'production') {
       if (!this._didProvideValidRef) {
         const { item } = this.props;
@@ -87,18 +85,12 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     // This is necessary to support the DynamicSizeList layout logic.
     this._measureItem(true, true);
 
-    const Test =
+    const WorkingResizeObserver =
       typeof ResizeObserver !== 'undefined' ? ResizeObserver : Polyfill;
-    this._resizeObserver = new Test(this._onResize);
+    this._resizeObserver = new WorkingResizeObserver(this._onResize);
     if (this._node !== null) {
       this._resizeObserver.observe(this._node);
     }
-    // if (typeof ResizeObserver !== 'undefined') {
-    //   // Watch for resizes due to changed content,
-    //   // Or changes in the size of the parent container.
-    //
-    //
-    // }
   }
 
   componentWillUnmount() {

--- a/src/ItemMeasurer.js
+++ b/src/ItemMeasurer.js
@@ -84,9 +84,11 @@ export default class ItemMeasurer extends Component<ItemMeasurerProps, void> {
     // Force sync measure for the initial mount.
     // This is necessary to support the DynamicSizeList layout logic.
     this._measureItem(true, true);
-
+  
     const WorkingResizeObserver =
       typeof ResizeObserver !== 'undefined' ? ResizeObserver : Polyfill;
+    // Watch for resizes due to changed content,
+    // Or changes in the size of the parent container.
     this._resizeObserver = new WorkingResizeObserver(this._onResize);
     if (this._node !== null) {
       this._resizeObserver.observe(this._node);


### PR DESCRIPTION
Safari (and other non top 3 browsers) do not support ResizeObservable api natively and there was a lot of glitching due to that lack of support for changing heights based on width of the window.

This pull request fixes that by using @juggle/resize-observer if no native ResizeObservable exists