### PR TITLE
fix: don't unecessarily re-order elements

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -445,6 +445,8 @@ export default function createGridComponent({
         }
       }
 
+      items.sort((a, b) => String(a.key).localeCompare(String(b.key)));
+
       // Read this value AFTER items have been created,
       // So their actual sizes (if variable) are taken into consideration.
       const estimatedTotalHeight = getEstimatedTotalHeight(


### PR DESCRIPTION
Since the element layout uses absolut positioning the order does not matter. Avoid re-ordering.