### PR TITLE
Add configurable `isScrolling` debounce time

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -74,6 +74,7 @@ export type Props<T> = {|
   innerRef?: any,
   innerElementType?: string | React$AbstractComponent<InnerProps, any>,
   innerTagName?: string, // deprecated
+  isScrollingDebounceInterval?: number,
   itemData: T,
   itemKey?: (params: {|
     columnIndex: number,
@@ -810,9 +811,15 @@ export default function createGridComponent({
         cancelTimeout(this._resetIsScrollingTimeoutId);
       }
 
+      const debounce =
+        this.props.isScrollingDebounceInterval === null ||
+        this.props.isScrollingDebounceInterval === undefined
+          ? IS_SCROLLING_DEBOUNCE_INTERVAL
+          : this.props.isScrollingDebounceInterval;
+
       this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
-        IS_SCROLLING_DEBOUNCE_INTERVAL
+        debounce
       );
     };
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -64,6 +64,7 @@ export type Props<T> = {|
   innerRef?: any,
   innerElementType?: string | React$AbstractComponent<InnerProps, any>,
   innerTagName?: string, // deprecated
+  isScrollingDebounceInterval?: number,
   itemCount: number,
   itemData: T,
   itemKey?: (index: number, data: T) => any,
@@ -614,9 +615,15 @@ export default function createListComponent({
         cancelTimeout(this._resetIsScrollingTimeoutId);
       }
 
+      const debounce =
+        this.props.isScrollingDebounceInterval === null ||
+        this.props.isScrollingDebounceInterval === undefined
+          ? IS_SCROLLING_DEBOUNCE_INTERVAL
+          : this.props.isScrollingDebounceInterval;
+
       this._resetIsScrollingTimeoutId = requestTimeout(
         this._resetIsScrolling,
-        IS_SCROLLING_DEBOUNCE_INTERVAL
+        debounce
       );
     };
 

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -157,6 +157,19 @@ const PROPS = [
     type: 'string',
   },
   {
+    defaultValue: 150,
+    description: (
+      <p>
+        The interval in ms since the last scroll event after which the
+        <code>isScrolling</code> prop passed to <code>children</code> will
+        switch back to <code>false</code>. Has no effect if the
+        <code>useIsScrolling</code> option is not set.
+      </p>
+    ),
+    name: 'isScrollingDebounceInterval',
+    type: 'number',
+  },
+  {
     description: (
       <Fragment>
         <p>

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -148,6 +148,19 @@ const PROPS = [
     type: 'string',
   },
   {
+    defaultValue: 150,
+    description: (
+      <p>
+        The interval in ms since the last scroll event after which the
+        <code>isScrolling</code> prop passed to <code>children</code> will
+        switch back to <code>false</code>. Has no effect if the
+        <code>useIsScrolling</code> option is not set.
+      </p>
+    ),
+    name: 'isScrollingDebounceInterval',
+    type: 'number',
+  },
+  {
     description: (
       <p>
         Total number of items in the list. Note that only a few items will be


### PR DESCRIPTION
Allows the user to configure the currently-fixed `IS_SCROLLING_DEBOUNCE_INTERVAL` value.

We're currently using a lower debounce in conjunction with a custom container element to overcome some performance issues while scrolling, by disabling render updates during scroll.