### PR TITLE
Add virtualized indexes to `itemKey` function calls

### DIFF
--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -1049,12 +1049,42 @@ describe('FixedSizeGrid', () => {
         />
       );
       expect(itemKey).toHaveBeenCalledTimes(6);
-      expect(itemKey.mock.calls[0][0]).toEqual({ columnIndex: 0, rowIndex: 0 });
-      expect(itemKey.mock.calls[1][0]).toEqual({ columnIndex: 1, rowIndex: 0 });
-      expect(itemKey.mock.calls[2][0]).toEqual({ columnIndex: 2, rowIndex: 0 });
-      expect(itemKey.mock.calls[3][0]).toEqual({ columnIndex: 0, rowIndex: 1 });
-      expect(itemKey.mock.calls[4][0]).toEqual({ columnIndex: 1, rowIndex: 1 });
-      expect(itemKey.mock.calls[5][0]).toEqual({ columnIndex: 2, rowIndex: 1 });
+      expect(itemKey.mock.calls[0][0]).toEqual({
+        columnIndex: 0,
+        rowIndex: 0,
+        virtualizedRowIndex: 0,
+        virtualizedColumnIndex: 0,
+      });
+      expect(itemKey.mock.calls[1][0]).toEqual({
+        columnIndex: 1,
+        rowIndex: 0,
+        virtualizedRowIndex: 0,
+        virtualizedColumnIndex: 1,
+      });
+      expect(itemKey.mock.calls[2][0]).toEqual({
+        columnIndex: 2,
+        rowIndex: 0,
+        virtualizedRowIndex: 0,
+        virtualizedColumnIndex: 2,
+      });
+      expect(itemKey.mock.calls[3][0]).toEqual({
+        columnIndex: 0,
+        rowIndex: 1,
+        virtualizedRowIndex: 1,
+        virtualizedColumnIndex: 0,
+      });
+      expect(itemKey.mock.calls[4][0]).toEqual({
+        columnIndex: 1,
+        rowIndex: 1,
+        virtualizedRowIndex: 1,
+        virtualizedColumnIndex: 1,
+      });
+      expect(itemKey.mock.calls[5][0]).toEqual({
+        columnIndex: 2,
+        rowIndex: 1,
+        virtualizedRowIndex: 1,
+        virtualizedColumnIndex: 2,
+      });
     });
 
     it('should allow items to be moved within the collection without causing caching problems', () => {
@@ -1122,6 +1152,33 @@ describe('FixedSizeGrid', () => {
       expect(
         itemKey.mock.calls.filter(([params]) => params.data === itemData)
       ).toHaveLength(itemKey.mock.calls.length);
+    });
+
+    it('should receive the correct virtualized row and column indexes when scrolled', () => {
+      getScrollbarSize.mockImplementation(() => 20);
+      const itemKey = jest.fn(
+        ({ columnIndex, rowIndex }) => `${rowIndex}-${columnIndex}`
+      );
+
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeGrid
+          {...defaultProps}
+          width={100}
+          height={25}
+          itemKey={itemKey}
+        />
+      );
+      onItemsRendered.mockClear();
+
+      expect(itemKey).toHaveBeenCalledTimes(4);
+      itemKey.mockClear();
+      // Scroll across to the last row in the list.
+      rendered
+        .getInstance()
+        .scrollToItem({ columnIndex: 19, rowIndex: 19, align: 'auto' });
+
+      expect(itemKey).toHaveBeenCalledTimes(16);
+      expect(itemKey.mock.calls).toMatchSnapshot();
     });
   });
 

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -714,6 +714,25 @@ describe('FixedSizeList', () => {
         itemKey.mock.calls.filter(([index, data]) => data === itemData)
       ).toHaveLength(itemKey.mock.calls.length);
     });
+
+    it('should receive the item index relative to the current rendered items as virtualizedIndex', () => {
+      const itemKey = jest.fn(index => index);
+
+      const rendered = ReactTestRenderer.create(
+        // Create list where items don't fit exactly into container.
+        // The container has space for 3 1/3 items.
+        <FixedSizeList {...defaultProps} itemSize={20} itemKey={itemKey} />
+      );
+
+      expect(itemKey).toHaveBeenCalledTimes(7);
+      expect(itemKey.mock.calls).toMatchSnapshot();
+      itemKey.mockClear();
+
+      rendered.getInstance().scrollToItem(10, 'auto');
+
+      expect(itemKey).toHaveBeenCalledTimes(9);
+      expect(itemKey.mock.calls).toMatchSnapshot();
+    });
   });
 
   describe('refs', () => {

--- a/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeGrid.js.snap
@@ -29,6 +29,155 @@ Array [
 ]
 `;
 
+exports[`FixedSizeGrid itemKey should receive the correct virtualized row and column indexes when scrolled 1`] = `
+Array [
+  Array [
+    Object {
+      "columnIndex": 18,
+      "data": undefined,
+      "rowIndex": 18,
+      "virtualizedColumnIndex": 0,
+      "virtualizedRowIndex": 0,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 19,
+      "data": undefined,
+      "rowIndex": 18,
+      "virtualizedColumnIndex": 1,
+      "virtualizedRowIndex": 0,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 20,
+      "data": undefined,
+      "rowIndex": 18,
+      "virtualizedColumnIndex": 2,
+      "virtualizedRowIndex": 0,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 21,
+      "data": undefined,
+      "rowIndex": 18,
+      "virtualizedColumnIndex": 3,
+      "virtualizedRowIndex": 0,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 18,
+      "data": undefined,
+      "rowIndex": 19,
+      "virtualizedColumnIndex": 0,
+      "virtualizedRowIndex": 1,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 19,
+      "data": undefined,
+      "rowIndex": 19,
+      "virtualizedColumnIndex": 1,
+      "virtualizedRowIndex": 1,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 20,
+      "data": undefined,
+      "rowIndex": 19,
+      "virtualizedColumnIndex": 2,
+      "virtualizedRowIndex": 1,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 21,
+      "data": undefined,
+      "rowIndex": 19,
+      "virtualizedColumnIndex": 3,
+      "virtualizedRowIndex": 1,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 18,
+      "data": undefined,
+      "rowIndex": 20,
+      "virtualizedColumnIndex": 0,
+      "virtualizedRowIndex": 2,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 19,
+      "data": undefined,
+      "rowIndex": 20,
+      "virtualizedColumnIndex": 1,
+      "virtualizedRowIndex": 2,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 20,
+      "data": undefined,
+      "rowIndex": 20,
+      "virtualizedColumnIndex": 2,
+      "virtualizedRowIndex": 2,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 21,
+      "data": undefined,
+      "rowIndex": 20,
+      "virtualizedColumnIndex": 3,
+      "virtualizedRowIndex": 2,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 18,
+      "data": undefined,
+      "rowIndex": 21,
+      "virtualizedColumnIndex": 0,
+      "virtualizedRowIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 19,
+      "data": undefined,
+      "rowIndex": 21,
+      "virtualizedColumnIndex": 1,
+      "virtualizedRowIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 20,
+      "data": undefined,
+      "rowIndex": 21,
+      "virtualizedColumnIndex": 2,
+      "virtualizedRowIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "columnIndex": 21,
+      "data": undefined,
+      "rowIndex": 21,
+      "virtualizedColumnIndex": 3,
+      "virtualizedRowIndex": 3,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeGrid onScroll scrolling should report partial items correctly in onItemsRendered 1`] = `
 Array [
   Array [

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -21,6 +21,96 @@ Array [
 ]
 `;
 
+exports[`FixedSizeList itemKey should receive the item index relative to the current rendered items as virtualizedIndex 1`] = `
+Array [
+  Array [
+    0,
+    undefined,
+    0,
+  ],
+  Array [
+    1,
+    undefined,
+    1,
+  ],
+  Array [
+    2,
+    undefined,
+    2,
+  ],
+  Array [
+    3,
+    undefined,
+    3,
+  ],
+  Array [
+    4,
+    undefined,
+    4,
+  ],
+  Array [
+    5,
+    undefined,
+    5,
+  ],
+  Array [
+    6,
+    undefined,
+    6,
+  ],
+]
+`;
+
+exports[`FixedSizeList itemKey should receive the item index relative to the current rendered items as virtualizedIndex 2`] = `
+Array [
+  Array [
+    4,
+    undefined,
+    0,
+  ],
+  Array [
+    5,
+    undefined,
+    1,
+  ],
+  Array [
+    6,
+    undefined,
+    2,
+  ],
+  Array [
+    7,
+    undefined,
+    3,
+  ],
+  Array [
+    8,
+    undefined,
+    4,
+  ],
+  Array [
+    9,
+    undefined,
+    5,
+  ],
+  Array [
+    10,
+    undefined,
+    6,
+  ],
+  Array [
+    11,
+    undefined,
+    7,
+  ],
+  Array [
+    12,
+    undefined,
+    8,
+  ],
+]
+`;
+
 exports[`FixedSizeList onScroll scrolling should report partial items correctly in onItemsRendered 1`] = `
 Array [
   Array [

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -79,6 +79,8 @@ export type Props<T> = {|
     columnIndex: number,
     data: T,
     rowIndex: number,
+    virtualizedRowIndex: number,
+    virtualizedColumnIndex: number,
   |}) => any,
   onItemsRendered?: OnItemsRenderedCallback,
   onScroll?: OnScrollCallback,
@@ -436,7 +438,13 @@ export default function createGridComponent({
                 columnIndex,
                 data: itemData,
                 isScrolling: useIsScrolling ? isScrolling : undefined,
-                key: itemKey({ columnIndex, data: itemData, rowIndex }),
+                key: itemKey({
+                  columnIndex,
+                  data: itemData,
+                  rowIndex,
+                  virtualizedRowIndex: rowIndex - rowStartIndex,
+                  virtualizedColumnIndex: columnIndex - columnStartIndex,
+                }),
                 rowIndex,
                 style: this._getItemStyle(rowIndex, columnIndex),
               })

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -66,7 +66,7 @@ export type Props<T> = {|
   innerTagName?: string, // deprecated
   itemCount: number,
   itemData: T,
-  itemKey?: (index: number, data: T) => any,
+  itemKey?: (index: number, data: T, virtualizedIndex: number) => any,
   itemSize: itemSize,
   layout: Layout,
   onItemsRendered?: onItemsRenderedCallback,
@@ -122,7 +122,7 @@ type ValidateProps = (props: Props<any>) => void;
 
 const IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 
-const defaultItemKey = (index: number, data: any) => index;
+const defaultItemKey = (index: number, data: any, _: number) => index;
 
 // In DEV mode, this Set helps us only log a warning once per component instance.
 // This avoids spamming the console every time a render happens.
@@ -324,7 +324,7 @@ export default function createListComponent({
           items.push(
             createElement(children, {
               data: itemData,
-              key: itemKey(index, itemData),
+              key: itemKey(index, itemData, index - startIndex),
               index,
               isScrolling: useIsScrolling ? isScrolling : undefined,
               style: this._getItemStyle(index),

--- a/website/src/code/FixedSizeGridStableItemKey.js
+++ b/website/src/code/FixedSizeGridStableItemKey.js
@@ -1,0 +1,13 @@
+function itemKey({ columnIndex, data, rowIndex, virtualizedColumnIndex, virtualizedRowIndex }) {
+  // virtualizedRowIndex and virtualizedColumnIndex are the indexes relative to the first
+  // rendered rows and columns respectively.
+
+  // Using virtualizedRowIndex and virtualizedColumnIndex as the key will be stable
+  // even when the user scrolls allowing for DOM re-use.
+  // When using sorting/filtering a visible element might need to be re-rendered if after
+  // filtering/sorting the element is still visible but on a different position although
+  // the chances of this happening get smaller the bigger the amount of items (as chances are 
+  // that after sorting or filtering different items would be visible on the viewport anyway)
+  // The same is true when the data changes causing new items to be added to the top
+  return `${virtualizedRowIndex}-${virtualizedColumnIndex}`;
+}

--- a/website/src/code/FixedSizeListStableItemKey.js
+++ b/website/src/code/FixedSizeListStableItemKey.js
@@ -1,0 +1,13 @@
+function itemKey(index, data, virtualizedIndex) {
+  // virtualizedIndex is the current index relative to the first
+  // rendered rows.
+
+  // Using virtualizedIndex as the key will be stable even when 
+  // the user scrolls allowing for DOM re-use.
+  // When using sorting/filtering a visible element might need to be re-rendered if after
+  // filtering/sorting the element is still visible but on a different position although
+  // the chances of this happening get smaller the bigger the amount of items (as chances are 
+  // that after sorting or filtering different items would be visible on the viewport anyway)
+  // The same is true when the data changes causing new items to be added to the top
+  return virtualizedIndex;
+}

--- a/website/src/routes/api/FixedSizeGrid.js
+++ b/website/src/routes/api/FixedSizeGrid.js
@@ -9,6 +9,7 @@ import CODE_CHILDREN_CLASS from '../../code/FixedSizeGridChildrenClass.js';
 import CODE_CHILDREN_FUNCTION from '../../code/FixedSizeGridChildrenFunction.js';
 import CODE_ITEM_DATA from '../../code/FixedSizeGridItemData.js';
 import CODE_ITEM_KEY from '../../code/FixedSizeGridItemKey.js';
+import CODE_ITEM_KEY_STABLE from '../../code/FixedSizeGridStableItemKey.js';
 import CODE_ON_ITEMS_RENDERED from '../../code/FixedSizeGridOnItemsRendered.js';
 import CODE_ON_SCROLL from '../../code/FixedSizeGridOnScroll.js';
 
@@ -194,6 +195,15 @@ const PROPS = [
         </p>
         <div className={styles.CodeBlockWrapper}>
           <CodeBlock value={CODE_ITEM_KEY} />
+        </div>
+        <p>
+          When implementing your own <code>itemKey</code> function, you can use
+          the virtualizedRowIndex and virtualizedColumnIndex to ensure the keys
+          are stable and, as such, prevent the components from re-mounting as
+          the user scrolls:
+        </p>
+        <div className={styles.CodeBlockWrapper}>
+          <CodeBlock value={CODE_ITEM_KEY_STABLE} />
         </div>
       </Fragment>
     ),

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -9,6 +9,7 @@ import CODE_CHILDREN_CLASS from '../../code/FixedSizeListChildrenClass.js';
 import CODE_CHILDREN_FUNCTION from '../../code/FixedSizeListChildrenFunction.js';
 import CODE_ITEM_DATA from '../../code/FixedSizeListItemData.js';
 import CODE_ITEM_KEY from '../../code/FixedSizeListItemKey.js';
+import CODE_ITEM_KEY_STABLE from '../../code/FixedSizeListStableItemKey.js';
 import CODE_ON_ITEMS_RENDERED from '../../code/FixedSizeListOnItemsRendered.js';
 import CODE_ON_SCROLL from '../../code/FixedSizeListOnScroll.js';
 
@@ -196,6 +197,14 @@ const PROPS = [
         </p>
         <div className={styles.CodeBlockWrapper}>
           <CodeBlock value={CODE_ITEM_KEY} />
+        </div>
+        <p>
+          If you want to re-use the DOM elements as the user scrolls, you can
+          leveradge the virtualizedIndex property passed to <code>itemKey</code>{' '}
+          to implement a stable key:
+        </p>
+        <div className={styles.CodeBlockWrapper}>
+          <CodeBlock value={CODE_ITEM_KEY_STABLE} />
         </div>
       </Fragment>
     ),


### PR DESCRIPTION
Currently only the real data index is passed to the `itemKey` functions for Grid and List components respectively.

While this is great to be able to get an unique key for each of the rendered items, when the user scrolls, the index will change causing the new key to mismatch the previous and React to unmount and re-mount each component and, as such, recreate the DOM node.

This PR adds a new parameter to the List component `itemKey` function call, `virtualizedIndex` which represents the row index relative to the first rendered row. Similarly, for Grids, there's two new properties: `virtualizedRowIndex`and `virtualizedColumnIndex`.

Depending on what we're optimising for, using these virtualized values instead can be a performance improvement and IMO it's quite good to have the additional option mostly when the code complexity remains pretty much the same.

Relates to: #234 