### PR TITLE
fix: make props more tolerant

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -34,22 +34,22 @@ type OnItemsRenderedCallback = ({
   visibleColumnStopIndex: number,
   visibleRowStartIndex: number,
   visibleRowStopIndex: number,
-}) => void;
+}) => mixed;
 type OnScrollCallback = ({
   horizontalScrollDirection: ScrollDirection,
   scrollLeft: number,
   scrollTop: number,
   scrollUpdateWasRequested: boolean,
   verticalScrollDirection: ScrollDirection,
-}) => void;
+}) => mixed;
 
 type ScrollEvent = SyntheticEvent<HTMLDivElement>;
 type ItemStyleCache = { [key: string]: Object };
 
 type OuterProps = {|
   children: React$Node,
-  className: string | void,
-  onScroll: ScrollEvent => void,
+  className: ?string,
+  onScroll: ScrollEvent => mixed,
   style: {
     [string]: mixed,
   },
@@ -64,35 +64,35 @@ type InnerProps = {|
 
 export type Props<T> = {|
   children: RenderComponent<T>,
-  className?: string,
+  className?: ?string,
   columnCount: number,
   columnWidth: itemSize,
   direction: Direction,
   height: number,
-  initialScrollLeft?: number,
-  initialScrollTop?: number,
+  initialScrollLeft?: ?number,
+  initialScrollTop?: ?number,
   innerRef?: any,
-  innerElementType?: string | React$AbstractComponent<InnerProps, any>,
-  innerTagName?: string, // deprecated
+  innerElementType?: ?(string | React$AbstractComponent<InnerProps, any>),
+  innerTagName?: ?string, // deprecated
   itemData: T,
-  itemKey?: (params: {|
+  itemKey?: ?(params: {|
     columnIndex: number,
     data: T,
     rowIndex: number,
   |}) => any,
-  onItemsRendered?: OnItemsRenderedCallback,
-  onScroll?: OnScrollCallback,
+  onItemsRendered?: ?OnItemsRenderedCallback,
+  onScroll?: ?OnScrollCallback,
   outerRef?: any,
-  outerElementType?: string | React$AbstractComponent<OuterProps, any>,
-  outerTagName?: string, // deprecated
-  overscanColumnCount?: number,
-  overscanColumnsCount?: number, // deprecated
-  overscanCount?: number, // deprecated
-  overscanRowCount?: number,
-  overscanRowsCount?: number, // deprecated
+  outerElementType?: ?(string | React$AbstractComponent<OuterProps, any>),
+  outerTagName?: ?string, // deprecated
+  overscanColumnCount?: ?number,
+  overscanColumnsCount?: ?number, // deprecated
+  overscanCount?: ?number, // deprecated
+  overscanRowCount?: ?number,
+  overscanRowsCount?: ?number, // deprecated
   rowCount: number,
   rowHeight: itemSize,
-  style?: Object,
+  style?: ?Object,
   useIsScrolling: boolean,
   width: number,
 |};
@@ -403,7 +403,6 @@ export default function createGridComponent({
         innerElementType,
         innerTagName,
         itemData,
-        itemKey = defaultItemKey,
         outerElementType,
         outerTagName,
         rowCount,
@@ -411,6 +410,7 @@ export default function createGridComponent({
         useIsScrolling,
         width,
       } = this.props;
+      const itemKey = this.props.itemKey || defaultItemKey;
       const { isScrolling } = this.state;
 
       const [

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -29,20 +29,20 @@ type onItemsRenderedCallback = ({
   overscanStopIndex: number,
   visibleStartIndex: number,
   visibleStopIndex: number,
-}) => void;
+}) => mixed;
 type onScrollCallback = ({
   scrollDirection: ScrollDirection,
   scrollOffset: number,
   scrollUpdateWasRequested: boolean,
-}) => void;
+}) => mixed;
 
 type ScrollEvent = SyntheticEvent<HTMLDivElement>;
 type ItemStyleCache = { [index: number]: Object };
 
 type OuterProps = {|
   children: React$Node,
-  className: string | void,
-  onScroll: ScrollEvent => void,
+  className: ?string,
+  onScroll: ScrollEvent => mixed,
   style: {
     [string]: mixed,
   },
@@ -57,25 +57,25 @@ type InnerProps = {|
 
 export type Props<T> = {|
   children: RenderComponent<T>,
-  className?: string,
+  className?: ?string,
   direction: Direction,
   height: number | string,
-  initialScrollOffset?: number,
-  innerRef?: any,
-  innerElementType?: string | React$AbstractComponent<InnerProps, any>,
-  innerTagName?: string, // deprecated
+  initialScrollOffset?: ?number,
+  innerRef?: ?any,
+  innerElementType?: ?(string | React$AbstractComponent<InnerProps, any>),
+  innerTagName?: ?string, // deprecated
   itemCount: number,
   itemData: T,
-  itemKey?: (index: number, data: T) => any,
+  itemKey?: ?(index: number, data: T) => any,
   itemSize: itemSize,
   layout: Layout,
   onItemsRendered?: onItemsRenderedCallback,
   onScroll?: onScrollCallback,
   outerRef?: any,
-  outerElementType?: string | React$AbstractComponent<OuterProps, any>,
-  outerTagName?: string, // deprecated
+  outerElementType?: ?(string | React$AbstractComponent<OuterProps, any>),
+  outerTagName?: ?string, // deprecated
   overscanCount: number,
-  style?: Object,
+  style?: ?Object,
   useIsScrolling: boolean,
   width: number | string,
 |};
@@ -298,7 +298,6 @@ export default function createListComponent({
         innerTagName,
         itemCount,
         itemData,
-        itemKey = defaultItemKey,
         layout,
         outerElementType,
         outerTagName,
@@ -306,6 +305,7 @@ export default function createListComponent({
         useIsScrolling,
         width,
       } = this.props;
+      const itemKey = this.props.itemKey || defaultItemKey;
       const { isScrolling } = this.state;
 
       // TODO Deprecate direction "horizontal"


### PR DESCRIPTION
There are two things here:
- use `mixed` return value for callback props so that arrow function expressions won't be flagged as errors
- change optional props like `className?: string` to `className?: ?string` so that it's easier for an enclosing component to pass through those props