### PR TITLE
Add mustRender prop for list components

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -98,6 +98,25 @@ describe('FixedSizeList', () => {
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
+  it('should throw when must-render items are out of bounds', () => {
+    spyOn(console, 'error');
+
+    expect(() => {
+      ReactTestRenderer.create(
+        <FixedSizeList
+          {...defaultProps}
+          mustRender={[defaultProps.itemCount]}
+        />
+      );
+    }).toThrow('Index in `mustRender` out of bounds');
+
+    expect(() => {
+      ReactTestRenderer.create(
+        <FixedSizeList {...defaultProps} mustRender={[-1]} />
+      );
+    }).toThrow('Index in `mustRender` out of bounds');
+  });
+
   it('should render a list of columns', () => {
     ReactTestRenderer.create(
       <FixedSizeList {...defaultProps} layout="horizontal" />

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -82,6 +82,14 @@ describe('FixedSizeList', () => {
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
+  it('should render items marked must-render', () => {
+    ReactTestRenderer.create(
+      <FixedSizeList {...defaultProps} mustRender={[99]} />
+    );
+    expect(itemRenderer).toHaveBeenCalledTimes(7);
+    expect(onItemsRendered.mock.calls).toMatchSnapshot();
+  });
+
   it('should render a list of columns', () => {
     ReactTestRenderer.create(
       <FixedSizeList {...defaultProps} layout="horizontal" />

--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -90,6 +90,14 @@ describe('FixedSizeList', () => {
     expect(onItemsRendered.mock.calls).toMatchSnapshot();
   });
 
+  it('should not double-render items marked must-render', () => {
+    ReactTestRenderer.create(
+      <FixedSizeList {...defaultProps} mustRender={[0]} />
+    );
+    expect(itemRenderer).toHaveBeenCalledTimes(6);
+    expect(onItemsRendered.mock.calls).toMatchSnapshot();
+  });
+
   it('should render a list of columns', () => {
     ReactTestRenderer.create(
       <FixedSizeList {...defaultProps} layout="horizontal" />

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -541,6 +541,19 @@ Array [
 ]
 `;
 
+exports[`FixedSizeList should not double-render items marked must-render 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeList should render a list of columns 1`] = `
 Array [
   Array [

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -566,3 +566,16 @@ Array [
   ],
 ]
 `;
+
+exports[`FixedSizeList should render items marked must-render 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+]
+`;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -342,6 +342,10 @@ export default function createListComponent({
             continue;
           }
 
+          if (index < 0 || index + 1 > itemCount) {
+            throw new Error('Index in `mustRender` out of bounds');
+          }
+
           items.push(
             createElement(children, {
               data: itemData,

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -78,6 +78,7 @@ export type Props<T> = {|
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
+  mustRender?: Array<number>,
 |};
 
 type State = {|
@@ -305,6 +306,7 @@ export default function createListComponent({
         style,
         useIsScrolling,
         width,
+        mustRender,
       } = this.props;
       const { isScrolling } = this.state;
 
@@ -321,6 +323,20 @@ export default function createListComponent({
       const items = [];
       if (itemCount > 0) {
         for (let index = startIndex; index <= stopIndex; index++) {
+          items.push(
+            createElement(children, {
+              data: itemData,
+              key: itemKey(index, itemData),
+              index,
+              isScrolling: useIsScrolling ? isScrolling : undefined,
+              style: this._getItemStyle(index),
+            })
+          );
+        }
+      }
+
+      if (mustRender) {
+        for (let index of mustRender) {
           items.push(
             createElement(children, {
               data: itemData,

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -78,7 +78,7 @@ export type Props<T> = {|
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
-  mustRender?: Array<number>,
+  mustRender?: Array<number> | null,
 |};
 
 type State = {|

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -338,6 +338,10 @@ export default function createListComponent({
 
       if (mustRender) {
         for (let index of mustRender) {
+          if (index >= startIndex && index <= stopIndex) {
+            continue;
+          }
+
           items.push(
             createElement(children, {
               data: itemData,

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -168,6 +168,7 @@ export default function createListComponent({
       layout: 'vertical',
       overscanCount: 2,
       useIsScrolling: false,
+      mustRender: null,
     };
 
     state: State = {

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -387,6 +387,18 @@ const PROPS = [
     name: 'width',
     type: 'number | string',
   },
+  {
+    defaultValue: null,
+    description: (
+      <Fragment>
+        <p>Forces rendering of the items at the indices provided. This can be
+        useful to ensure something remains focused as it scrolls off-screen,
+        for example.</p>
+      </Fragment>
+    ),
+    name: 'mustRender',
+    type: 'number[]'
+  }
 ];
 
 const METHODS = [

--- a/website/src/routes/api/FixedSizeList.js
+++ b/website/src/routes/api/FixedSizeList.js
@@ -391,14 +391,16 @@ const PROPS = [
     defaultValue: null,
     description: (
       <Fragment>
-        <p>Forces rendering of the items at the indices provided. This can be
-        useful to ensure something remains focused as it scrolls off-screen,
-        for example.</p>
+        <p>
+          Forces rendering of the items at the indices provided. This can be
+          useful to ensure something remains focused as it scrolls off-screen,
+          for example.
+        </p>
       </Fragment>
     ),
     name: 'mustRender',
-    type: 'number[]'
-  }
+    type: 'number[]',
+  },
 ];
 
 const METHODS = [


### PR DESCRIPTION
This adds a `mustRender` prop for list components. An array of item indices can be provided, and react-window will render those items regardless of scroll position.

This feature is useful for cases where one may want to preserve focus on a component that the user may scroll off-screen. When it's scrolled back on-screen, one has to call `focus()` on it to maintain that focus state. Simply calling `focus()` on the elements when they're rendered is insufficient, as Safari does not support the `preventScroll` option that would prevent the browser from jumping immediately to some number of pixels past the newly-rendered focused component.