### PR TITLE
Add functionality to accurately calculate remaining height in VariableSizeList

### DIFF
--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -8,6 +8,7 @@ const DEFAULT_ESTIMATED_ITEM_SIZE = 50;
 
 type VariableSizeProps = {|
   estimatedItemSize: number,
+  getEstimatedRemainingHeight: (index: number) => number,
   ...Props<any>,
 |};
 
@@ -20,6 +21,7 @@ type ItemMetadata = {|
 type InstanceProps = {|
   itemMetadataMap: { [index: number]: ItemMetadata },
   estimatedItemSize: number,
+  getEstimatedRemainingHeight: (index: number) => number,
   lastMeasuredIndex: number,
 |};
 
@@ -142,7 +144,12 @@ const findNearestItemExponentialSearch = (
 
 const getEstimatedTotalSize = (
   { itemCount }: Props<any>,
-  { itemMetadataMap, estimatedItemSize, lastMeasuredIndex }: InstanceProps
+  {
+    itemMetadataMap,
+    estimatedItemSize,
+    getEstimatedRemainingHeight,
+    lastMeasuredIndex,
+  }: InstanceProps
 ) => {
   let totalSizeOfMeasuredItems = 0;
 
@@ -155,6 +162,13 @@ const getEstimatedTotalSize = (
   if (lastMeasuredIndex >= 0) {
     const itemMetadata = itemMetadataMap[lastMeasuredIndex];
     totalSizeOfMeasuredItems = itemMetadata.offset + itemMetadata.size;
+  }
+
+  if (getEstimatedRemainingHeight != null) {
+    return (
+      totalSizeOfMeasuredItems +
+      getEstimatedRemainingHeight(lastMeasuredIndex + 1)
+    );
   }
 
   const numUnmeasuredItems = itemCount - lastMeasuredIndex - 1;
@@ -267,11 +281,15 @@ const VariableSizeList = createListComponent({
   },
 
   initInstanceProps(props: Props<any>, instance: any): InstanceProps {
-    const { estimatedItemSize } = ((props: any): VariableSizeProps);
+    const {
+      estimatedItemSize,
+      getEstimatedRemainingHeight,
+    } = ((props: any): VariableSizeProps);
 
     const instanceProps = {
       itemMetadataMap: {},
       estimatedItemSize: estimatedItemSize || DEFAULT_ESTIMATED_ITEM_SIZE,
+      getEstimatedRemainingHeight: getEstimatedRemainingHeight || null,
       lastMeasuredIndex: -1,
     };
 


### PR DESCRIPTION
## Problem:
Our `VariableSizeList` has very varied row heights. The default `estimatedItemSize` does not accurately represent the total height of the list.

This means users see a lot of jumpiness when scrolling down with the scrollbar. 

## Solution:
Adding `getEstimatedRemainingHeight` optional prop that returns an estimation of the remaining list height.
This function is passed the last measured index and expects to return the remaining height.

If accepted, I can add website documentation changes. I'm also open for a better name.