### PR TITLE
Improve scrolling behaviour for VariableSizeList with align='center'

### DIFF
--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -222,7 +222,18 @@ const VariableSizeList = createListComponent({
       case 'end':
         return minOffset;
       case 'center':
-        return Math.round(minOffset + (maxOffset - minOffset) / 2);
+        const itemMidPoint =
+          itemMetadata.offset + Math.ceil(itemMetadata.size / 2);
+        if (itemMetadata.offset < Math.floor(size / 2)) {
+          // The row is above the midpoint of the first full window so centering
+          // it is best achieved by scrolling to the top
+          return 0;
+        } else if (itemMidPoint > estimatedTotalSize - Math.ceil(size / 2)) {
+          // The row is below the midpoint of the last full window
+          return Math.max(0, estimatedTotalSize - size);
+        } else {
+          return Math.round(minOffset + (maxOffset - minOffset) / 2);
+        }
       case 'auto':
       default:
         if (scrollOffset >= minOffset && scrollOffset <= maxOffset) {

--- a/src/__tests__/VariableSizeList.js
+++ b/src/__tests__/VariableSizeList.js
@@ -210,11 +210,11 @@ describe('VariableSizeList', () => {
       // Scroll down enough to show item 10 at the top.
       rendered.getInstance().scrollToItem(10, 'start');
       // Scroll back up so that item 9 is at the top.
-      // Overscroll direction wil change too.
+      // Overscroll direction will change too.
       rendered.getInstance().scrollToItem(9, 'start');
       // Item 19 can't align at the top because there aren't enough items.
       // Scroll down as far as possible though.
-      // Overscroll direction wil change again.
+      // Overscroll direction will change again.
       rendered.getInstance().scrollToItem(19, 'start');
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
@@ -227,11 +227,11 @@ describe('VariableSizeList', () => {
       // Scroll down enough to show item 10 at the bottom.
       rendered.getInstance().scrollToItem(10, 'end');
       // Scroll back up so that item 9 is at the bottom.
-      // Overscroll direction wil change too.
+      // Overscroll direction will change too.
       rendered.getInstance().scrollToItem(9, 'end');
       // Item 1 can't align at the bottom because it's too close to the beginning.
       // Scroll up as far as possible though.
-      // Overscroll direction wil change again.
+      // Overscroll direction will change again.
       rendered.getInstance().scrollToItem(1, 'end');
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });
@@ -244,16 +244,16 @@ describe('VariableSizeList', () => {
       // Scroll down enough to show item 10 in the middle.
       rendered.getInstance().scrollToItem(10, 'center');
       // Scroll back up so that item 9 is in the middle.
-      // Overscroll direction wil change too.
+      // Overscroll direction will change too.
       rendered.getInstance().scrollToItem(9, 'center');
       // Item 1 can't align in the middle because it's too close to the beginning.
       // Scroll up as far as possible though.
-      // Overscroll direction wil change again.
+      // Overscroll direction will change again.
       rendered.getInstance().scrollToItem(1, 'center');
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
       // Item 19 can't align in the middle because it's too close to the end.
       // Scroll down as far as possible though.
-      // Overscroll direction wil change again.
+      // Overscroll direction will change again.
       rendered.getInstance().scrollToItem(19, 'center');
       expect(onItemsRendered.mock.calls).toMatchSnapshot();
     });

--- a/src/__tests__/__snapshots__/VariableSizeList.js.snap
+++ b/src/__tests__/__snapshots__/VariableSizeList.js.snap
@@ -166,9 +166,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
 ]
@@ -203,9 +203,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
   Array [
@@ -285,9 +285,9 @@ Array [
   Array [
     Object {
       "overscanStartIndex": 0,
-      "overscanStopIndex": 6,
+      "overscanStopIndex": 5,
       "visibleStartIndex": 0,
-      "visibleStopIndex": 4,
+      "visibleStopIndex": 3,
     },
   ],
 ]


### PR DESCRIPTION
The original behaviour computed the average of the minimum and maximum offsets which worked for centering on items in the middle but would not produce the nearest offset to centered for items at the extreme ends of the list.

This is similar to part of #274 which only changed the calculation for FixedSizeList.