### PR TITLE
increasing range of memoize-one to include 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "memoize-one": ">=3.1.1 <6"
+    "memoize-one": ">=3.1.1 <7"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5642,10 +5642,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-"memoize-one@>=3.1.1 <6":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
-  integrity sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw==
+"memoize-one@>=3.1.1 <7":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"


### PR DESCRIPTION
`memoize-one@6.x` is an API compatible breaking change, with stronger TypeScript types

→ https://github.com/alexreardon/memoize-one/releases/tag/v6.0.0