### PR TITLE
fix: Calling `scrollToItem` or `scrollTo` triggers onScroll twice

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -195,6 +195,7 @@ export default function createGridComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
     _outerRef: ?HTMLDivElement;
+    _isPerformingImperativeScrolling: boolean = false;
 
     static defaultProps = {
       direction: 'ltr',
@@ -247,6 +248,8 @@ export default function createGridComponent({
       if (scrollTop !== undefined) {
         scrollTop = Math.max(0, scrollTop);
       }
+
+      this._isPerformingImperativeScrolling = true;
 
       this.setState(prevState => {
         if (scrollLeft === undefined) {
@@ -737,6 +740,12 @@ export default function createGridComponent({
         scrollHeight,
         scrollWidth,
       } = event.currentTarget;
+
+      if (this._isPerformingImperativeScrolling) {
+        this._isPerformingImperativeScrolling = false;
+        return;
+      }
+
       this.setState(prevState => {
         if (
           prevState.scrollLeft === scrollLeft &&

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -160,6 +160,7 @@ export default function createListComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
+    _isPerformingImperativeScrolling: boolean = false;
 
     static defaultProps = {
       direction: 'ltr',
@@ -198,6 +199,8 @@ export default function createListComponent({
 
     scrollTo(scrollOffset: number): void {
       scrollOffset = Math.max(0, scrollOffset);
+
+      this._isPerformingImperativeScrolling = true;
 
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollOffset) {
@@ -524,6 +527,11 @@ export default function createListComponent({
     }
 
     _onScrollHorizontal = (event: ScrollEvent): void => {
+      if (this._isPerformingImperativeScrolling) {
+        this._isPerformingImperativeScrolling = false;
+        return;
+      }
+
       const { clientWidth, scrollLeft, scrollWidth } = event.currentTarget;
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollLeft) {
@@ -568,6 +576,10 @@ export default function createListComponent({
     };
 
     _onScrollVertical = (event: ScrollEvent): void => {
+      if (this._isPerformingImperativeScrolling) {
+        this._isPerformingImperativeScrolling = false;
+        return;
+      }
       const { clientHeight, scrollHeight, scrollTop } = event.currentTarget;
       this.setState(prevState => {
         if (prevState.scrollOffset === scrollTop) {


### PR DESCRIPTION
Basically every time that the imperative scroll is being performed it would trigger a call to the `_onScroll` method, and that way there would be 2 events for each `scrollTo*`(one of them with `scrollUpdateWasRequested` as true, and the other as `false`). This fixes https://github.com/bvaughn/react-window/issues/228