### PR TITLE
fix: optimization scrollLeft and scrollTop assignment performance

### DIFF
--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -377,10 +377,14 @@ export default function createGridComponent({
               break;
           }
         } else {
-          outerRef.scrollLeft = Math.max(0, scrollLeft);
+          requestAnimationFrame(() => {
+            outerRef.scrollLeft = Math.max(0, scrollLeft);
+          })
         }
 
-        outerRef.scrollTop = Math.max(0, scrollTop);
+        requestAnimationFrame(() => {
+          outerRef.scrollTop = Math.max(0, scrollTop);
+        })
       }
 
       this._callPropsCallbacks();

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -195,6 +195,8 @@ export default function createGridComponent({
     _instanceProps: any = initInstanceProps(this.props, this);
     _resetIsScrollingTimeoutId: TimeoutID | null = null;
     _outerRef: ?HTMLDivElement;
+    _outerRefScrollLeftRafId = null;
+    _outerRefScrollTopRafId = null;
 
     static defaultProps = {
       direction: 'ltr',
@@ -377,12 +379,14 @@ export default function createGridComponent({
               break;
           }
         } else {
-          requestAnimationFrame(() => {
+          cancelAnimationFrame(this._outerRefScrollLeftRafId);
+          this._outerRefScrollLeftRafId = requestAnimationFrame(() => {
             outerRef.scrollLeft = Math.max(0, scrollLeft);
           })
         }
 
-        requestAnimationFrame(() => {
+        cancelAnimationFrame(this._outerRefScrollTopRafId);
+        this._outerRefScrollTopRafId = requestAnimationFrame(() => {
           outerRef.scrollTop = Math.max(0, scrollTop);
         })
       }


### PR DESCRIPTION
When I re-rendered the table, I found that Recalculate Style was very time-consuming。
![image](https://user-images.githubusercontent.com/36876080/147398888-ff780358-a253-4587-8087-bbf0aa1c907c.png)

I guess the general reason is: when I slide the table, the columns of the table will be regenerated and rendered, and the sliding of the virtual hidden column in the middle also needs to follow the rhythm.

And I guess that the layout tree of the browser is laid out from top to bottom, and it will be very time-consuming to calculate the scrollLeft.

The solution is to throw the re-assignment calculation of scrollLeft and scrollTop into requestAnimationFrame. Let the reassignment operation not block the current react rendering process.
![image](https://user-images.githubusercontent.com/36876080/147398891-78edb0ae-c1c4-4605-9c61-b7e3c25665b2.png)

