### PR TITLE
Feature: allow additional elements inside the outer element in a List Component

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -78,6 +78,7 @@ export type Props<T> = {|
   style?: Object,
   useIsScrolling: boolean,
   width: number | string,
+  additionalElements: React$AbstractComponent<T>,
 |};
 
 type State = {|
@@ -305,6 +306,7 @@ export default function createListComponent({
         style,
         useIsScrolling,
         width,
+        additionalElements
       } = this.props;
       const { isScrolling } = this.state;
 
@@ -357,7 +359,7 @@ export default function createListComponent({
             ...style,
           },
         },
-        createElement(innerElementType || innerTagName || 'div', {
+        [createElement(innerElementType || innerTagName || 'div', {
           children: items,
           ref: innerRef,
           style: {
@@ -365,7 +367,7 @@ export default function createListComponent({
             pointerEvents: isScrolling ? 'none' : undefined,
             width: isHorizontal ? estimatedTotalSize : '100%',
           },
-        })
+        }), additionalElements ? additionalElements : null]
       );
     }
 


### PR DESCRIPTION
For Feature Request #442

Allow additional elements to be added to the outer element:
![image](https://user-images.githubusercontent.com/615016/149529852-ddb9f27f-a8ad-4d78-9215-ebd6f5b2e4c9.png)

So elements with absolute position, like arrows, lines, etc, can be added in a maintainable fashion, while still scrolling perfectly without any workarounds.