### PR TITLE
List scrollbar size

### DIFF
--- a/src/FixedSizeList.js
+++ b/src/FixedSizeList.js
@@ -4,6 +4,8 @@ import createListComponent from './createListComponent';
 
 import type { Props, ScrollToAlign } from './createListComponent';
 
+type InstanceProps = any;
+
 const FixedSizeList = createListComponent({
   getItemOffset: ({ itemSize }: Props<any>, index: number): number =>
     index * ((itemSize: any): number),
@@ -18,7 +20,9 @@ const FixedSizeList = createListComponent({
     { direction, height, itemCount, itemSize, layout, width }: Props<any>,
     index: number,
     align: ScrollToAlign,
-    scrollOffset: number
+    scrollOffset: number,
+    instanceProps: InstanceProps,
+    scrollbarSize: number
   ): number => {
     // TODO Deprecate direction "horizontal"
     const isHorizontal = direction === 'horizontal' || layout === 'horizontal';
@@ -33,7 +37,10 @@ const FixedSizeList = createListComponent({
     );
     const minOffset = Math.max(
       0,
-      index * ((itemSize: any): number) - size + ((itemSize: any): number)
+      index * ((itemSize: any): number) -
+        size +
+        ((itemSize: any): number) +
+        scrollbarSize
     );
 
     if (align === 'smart') {

--- a/src/VariableSizeList.js
+++ b/src/VariableSizeList.js
@@ -183,7 +183,8 @@ const VariableSizeList = createListComponent({
     index: number,
     align: ScrollToAlign,
     scrollOffset: number,
-    instanceProps: InstanceProps
+    instanceProps: InstanceProps,
+    scrollbarSize: number
   ): number => {
     const { direction, height, layout, width } = props;
 
@@ -202,7 +203,7 @@ const VariableSizeList = createListComponent({
     );
     const minOffset = Math.max(
       0,
-      itemMetadata.offset - size + itemMetadata.size
+      itemMetadata.offset - size + itemMetadata.size + scrollbarSize
     );
 
     if (align === 'smart') {

--- a/src/__tests__/FixedSizeGrid.js
+++ b/src/__tests__/FixedSizeGrid.js
@@ -1058,7 +1058,10 @@ describe('FixedSizeGrid', () => {
     });
 
     it('should allow items to be moved within the collection without causing caching problems', () => {
-      const keyMap = [['0:0', '0:1:', '0:2'], ['1:0', '1:1:', '1:2']];
+      const keyMap = [
+        ['0:0', '0:1:', '0:2'],
+        ['1:0', '1:1:', '1:2'],
+      ];
       const keyMapItemRenderer = jest.fn(({ index, style }) => (
         <div style={style}>{keyMap[index]}</div>
       ));

--- a/src/__tests__/__snapshots__/FixedSizeList.js.snap
+++ b/src/__tests__/__snapshots__/FixedSizeList.js.snap
@@ -272,6 +272,35 @@ Array [
 ]
 `;
 
+exports[`FixedSizeList scrollToItem method should account for scrollbar size 1`] = `
+Array [
+  Array [
+    Object {
+      "overscanStartIndex": 0,
+      "overscanStopIndex": 5,
+      "visibleStartIndex": 0,
+      "visibleStopIndex": 3,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 15,
+      "overscanStopIndex": 22,
+      "visibleStartIndex": 17,
+      "visibleStopIndex": 20,
+    },
+  ],
+  Array [
+    Object {
+      "overscanStartIndex": 15,
+      "overscanStopIndex": 23,
+      "visibleStartIndex": 17,
+      "visibleStopIndex": 21,
+    },
+  ],
+]
+`;
+
 exports[`FixedSizeList scrollToItem method should ignore indexes greater than itemCount 1`] = `
 Array [
   Array [

--- a/website/sandboxes/fixed-size-grid/index.js
+++ b/website/sandboxes/fixed-size-grid/index.js
@@ -12,8 +12,8 @@ const Cell = ({ columnIndex, rowIndex, style }) => (
           ? 'GridItemOdd'
           : 'GridItemEven'
         : rowIndex % 2
-          ? 'GridItemOdd'
-          : 'GridItemEven'
+        ? 'GridItemOdd'
+        : 'GridItemEven'
     }
     style={style}
   >

--- a/website/sandboxes/scrolling-to-a-grid-item/index.js
+++ b/website/sandboxes/scrolling-to-a-grid-item/index.js
@@ -12,8 +12,8 @@ const Cell = ({ columnIndex, rowIndex, style }) => (
           ? 'GridItemOdd'
           : 'GridItemEven'
         : rowIndex % 2
-          ? 'GridItemOdd'
-          : 'GridItemEven'
+        ? 'GridItemOdd'
+        : 'GridItemEven'
     }
     style={style}
   >

--- a/website/sandboxes/variable-size-grid/index.js
+++ b/website/sandboxes/variable-size-grid/index.js
@@ -21,8 +21,8 @@ const Cell = ({ columnIndex, rowIndex, style }) => (
           ? 'GridItemOdd'
           : 'GridItemEven'
         : rowIndex % 2
-          ? 'GridItemOdd'
-          : 'GridItemEven'
+        ? 'GridItemOdd'
+        : 'GridItemEven'
     }
     style={style}
   >

--- a/website/src/components/ComponentApi.js
+++ b/website/src/components/ComponentApi.js
@@ -68,19 +68,21 @@ export default class ComponentApi extends Component<Props, State> {
           </h2>
           {propsIntro}
           <dl className={styles.ComponentApiPropList}>
-            {props.filter(prop => showAll || prop.isRequired).map(prop => (
-              <Fragment key={prop.name}>
-                <dt className={styles.ComponentApiPropType}>
-                  {prop.name}: {prop.type}{' '}
-                  {prop.defaultValue !== undefined
-                    ? ` = ${prop.defaultValue}`
-                    : null}
-                </dt>
-                <dd className={styles.ComponentApiPropDefinition}>
-                  {prop.description}
-                </dd>
-              </Fragment>
-            ))}
+            {props
+              .filter(prop => showAll || prop.isRequired)
+              .map(prop => (
+                <Fragment key={prop.name}>
+                  <dt className={styles.ComponentApiPropType}>
+                    {prop.name}: {prop.type}{' '}
+                    {prop.defaultValue !== undefined
+                      ? ` = ${prop.defaultValue}`
+                      : null}
+                  </dt>
+                  <dd className={styles.ComponentApiPropDefinition}>
+                    {prop.description}
+                  </dd>
+                </Fragment>
+              ))}
           </dl>
           <h2 id="methods" className={styles.ComponentApiSubHeader}>
             Methods

--- a/website/src/components/ProfiledExample.js
+++ b/website/src/components/ProfiledExample.js
@@ -72,7 +72,7 @@ export default class ProfiledExample extends PureComponent<Props, void> {
     }
     if (this._averageTimeRef.current !== null) {
       this._averageTimeRef.current.textContent = `${Math.round(
-        this._totalActualTime / this._numCommits * 10
+        (this._totalActualTime / this._numCommits) * 10
       ) / 10}ms`;
     }
   }

--- a/website/src/routes/api/VariableSizeGrid.js
+++ b/website/src/routes/api/VariableSizeGrid.js
@@ -16,7 +16,8 @@ export default () => (
         This component has the same methods as{' '}
         <Link to="/api/FixedSizeGrid#methods">
           <code>FixedSizeGrid</code>
-        </Link>, but with the following additions:
+        </Link>
+        , but with the following additions:
       </p>
     }
     name="VariableSizeGrid"
@@ -26,7 +27,8 @@ export default () => (
         This component has the same props as{' '}
         <Link to="/api/FixedSizeGrid#props">
           <code>FixedSizeGrid</code>
-        </Link>, but with the following additions:
+        </Link>
+        , but with the following additions:
       </p>
     }
   />

--- a/website/src/routes/api/VariableSizeList.js
+++ b/website/src/routes/api/VariableSizeList.js
@@ -15,7 +15,8 @@ export default () => (
         This component has the same methods as{' '}
         <Link to="/api/FixedSizeList#methods">
           <code>FixedSizeList</code>
-        </Link>, but with the following additions:
+        </Link>
+        , but with the following additions:
       </p>
     }
     name="VariableSizeList"
@@ -25,7 +26,8 @@ export default () => (
         This component has the same props as{' '}
         <Link to="/api/FixedSizeList#props">
           <code>FixedSizeList</code>
-        </Link>, but with the following additions:
+        </Link>
+        , but with the following additions:
       </p>
     }
   />

--- a/website/src/routes/api/areEqual.js
+++ b/website/src/routes/api/areEqual.js
@@ -13,7 +13,8 @@ export default () => (
       Custom comparison function for{' '}
       <a href="https://reactjs.org/docs/react-api.html#reactmemo">
         <code>React.memo</code>
-      </a>. If your item renderer is a class component, use the{' '}
+      </a>
+      . If your item renderer is a class component, use the{' '}
       <Link to="/api/shouldComponentUpdate">
         <code>shouldComponentUpdate</code>
       </Link>{' '}

--- a/website/src/routes/examples/FixedSizeGrid.js
+++ b/website/src/routes/examples/FixedSizeGrid.js
@@ -19,8 +19,8 @@ class Cell extends PureComponent {
               ? styles.GridItemOdd
               : styles.GridItemEven
             : rowIndex % 2
-              ? styles.GridItemOdd
-              : styles.GridItemEven
+            ? styles.GridItemOdd
+            : styles.GridItemEven
         }
         style={style}
       >

--- a/website/src/routes/examples/RTLLayout.js
+++ b/website/src/routes/examples/RTLLayout.js
@@ -20,8 +20,8 @@ class Cell extends PureComponent {
               ? styles.GridItemOdd
               : styles.GridItemEven
             : rowIndex % 2
-              ? styles.GridItemOdd
-              : styles.GridItemEven
+            ? styles.GridItemOdd
+            : styles.GridItemEven
         }
         style={style}
       >

--- a/website/src/routes/examples/ScrollToItem.js
+++ b/website/src/routes/examples/ScrollToItem.js
@@ -41,8 +41,8 @@ class GridItemRenderer extends PureComponent {
               ? styles.GridItemOdd
               : styles.GridItemEven
             : rowIndex % 2
-              ? styles.GridItemOdd
-              : styles.GridItemEven
+            ? styles.GridItemOdd
+            : styles.GridItemEven
         }
         style={style}
       >

--- a/website/src/routes/examples/VariableSizeGrid.js
+++ b/website/src/routes/examples/VariableSizeGrid.js
@@ -23,8 +23,8 @@ class Cell extends PureComponent {
               ? styles.GridItemOdd
               : styles.GridItemEven
             : rowIndex % 2
-              ? styles.GridItemOdd
-              : styles.GridItemEven
+            ? styles.GridItemOdd
+            : styles.GridItemEven
         }
         style={style}
       >


### PR DESCRIPTION
`scrollToItem` accounts for scrollbar size in the uncommon case where a List component has scrolling in the non-dominant direction (e.g. a "vertical" layout list also scrolls horizontally).