### PR TITLE
fix scrollDirection when direction is RTL

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -580,7 +580,7 @@ export default function createListComponent({
         return {
           isScrolling: true,
           scrollDirection:
-            prevState.scrollOffset < scrollLeft ? 'forward' : 'backward',
+            prevState.scrollOffset < scrollOffset ? 'forward' : 'backward',
           scrollOffset,
           scrollUpdateWasRequested: false,
         };


### PR DESCRIPTION
To determine the `scrollDirection` in the `_onScrollHorizontal` method it compares the previous state's `scrollOffset` with the current `scrollLeft` value of the target. For browsers whose "RTLOffsetType" is "negative", this results in the `scrollDirection` being set to "backward".

The `scrollOffset` state value has been converted to a positive number or zero, and the `scrollLeft` value of the target (when "RTLOffsetType" is "negative") is a negative number. When comparing `prevState.scrollOffset < scrollLeft` it is always false because a positive value or zero is never greater than a negative value.

Proposed fix: compare `prevState.scrollOffset < scrollOffset` because `scrollOffset` has already been transformed in the same way that `prevState.scrollOffset` was transformed.

This pull request is intended to address this bug https://github.com/bvaughn/react-window/issues/689.