### PR TITLE
WIP: add before/after slot hook for List and Grid components

### DIFF
--- a/src/__tests__/FixedSizeList.js
+++ b/src/__tests__/FixedSizeList.js
@@ -163,6 +163,69 @@ describe('FixedSizeList', () => {
     });
   });
 
+  describe('slot elements', () => {
+    it('should render a slot element before the inner element', () => {
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeList
+          {...defaultProps}
+          innerElementType="inner-element"
+          before={<div id="before-element">before</div>}
+        />
+      );
+
+      const beforeElement = rendered.root.findByProps({ id: 'before-element' });
+      const innerElement = rendered.root.findByType('inner-element');
+
+      expect(beforeElement).toBeDefined();
+      expect(beforeElement).toBeDefined();
+      expect(beforeElement.parent).toEqual(innerElement.parent);
+
+      const { children } = beforeElement.parent;
+      expect(children.at(0)).toEqual(beforeElement);
+      expect(children.at(1)).toEqual(innerElement);
+    });
+
+    it('should render a slot element after the inner element', () => {
+      const rendered = ReactTestRenderer.create(
+        <FixedSizeList
+          {...defaultProps}
+          innerElementType="inner-element"
+          after={<div id="after-element">after</div>}
+        />
+      );
+
+      const afterElement = rendered.root.findByProps({ id: 'after-element' });
+      const innerElement = rendered.root.findByType('inner-element');
+
+      expect(afterElement).toBeDefined();
+      expect(afterElement).toBeDefined();
+      expect(afterElement.parent).toEqual(innerElement.parent);
+
+      const { children } = afterElement.parent;
+      expect(children.at(0)).toEqual(innerElement);
+      expect(children.at(1)).toEqual(afterElement);
+    });
+  });
+
+  it('should render slot elements for callbacks', () => {
+    const renderBefore = jest.fn(() => <div id="before-element">before</div>);
+    const renderAfter = jest.fn(() => <div id="after-element">after</div>);
+    const rendered = ReactTestRenderer.create(
+      <FixedSizeList
+        {...defaultProps}
+        innerElementType="inner-element"
+        before={renderBefore}
+        after={renderAfter}
+      />
+    );
+
+    expect(renderBefore).toHaveBeenCalled();
+    expect(rendered.root.findByProps({ id: 'before-element' })).toBeDefined();
+
+    expect(renderAfter).toHaveBeenCalled();
+    expect(rendered.root.findByProps({ id: 'after-element' })).toBeDefined();
+  });
+
   describe('style caching', () => {
     it('should cache styles while scrolling to avoid breaking pure sCU for items', () => {
       const rendered = ReactTestRenderer.create(
@@ -601,7 +664,7 @@ describe('FixedSizeList', () => {
       const ref = createRef();
       ReactDOM.render(
         <FixedSizeList {...defaultProps} ref={ref} />,
-        document.createElement('div'),
+        document.createElement('div')
       );
 
       // Mimic the vertical list not being horizontally scrollable.

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -6,6 +6,7 @@ import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 
 import type { TimeoutID } from './timer';
+import { getSlot } from './getSlot';
 
 type Direction = 'ltr' | 'rtl';
 export type ScrollToAlign = 'auto' | 'smart' | 'center' | 'start' | 'end';
@@ -62,8 +63,12 @@ type InnerProps = {|
   },
 |};
 
+type SlotRenderer = () => React$Node;
+
 export type Props<T> = {|
   children: RenderComponent<T>,
+  before?: SlotRenderer | React$Node,
+  after?: SlotRenderer | React$Node,
   className?: string,
   columnCount: number,
   columnWidth: itemSize,
@@ -395,6 +400,8 @@ export default function createGridComponent({
     render() {
       const {
         children,
+        before,
+        after,
         className,
         columnCount,
         direction,
@@ -473,6 +480,7 @@ export default function createGridComponent({
             ...style,
           },
         },
+        getSlot(before),
         createElement(innerElementType || innerTagName || 'div', {
           children: items,
           ref: innerRef,
@@ -481,7 +489,8 @@ export default function createGridComponent({
             pointerEvents: isScrolling ? 'none' : undefined,
             width: estimatedTotalWidth,
           },
-        })
+        }),
+        getSlot(after),
       );
     }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -6,6 +6,8 @@ import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 
 import type { TimeoutID } from './timer';
+import { create } from "domain";
+import { getSlot } from './getSlot';
 
 export type ScrollToAlign = 'auto' | 'smart' | 'center' | 'start' | 'end';
 
@@ -55,8 +57,12 @@ type InnerProps = {|
   },
 |};
 
+type SlotRenderer = () => React$Node;
+
 export type Props<T> = {|
   children: RenderComponent<T>,
+  before?: SlotRenderer | React$Node,
+  after?: SlotRenderer | React$Node,
   className?: string,
   direction: Direction,
   height: number | string,
@@ -310,6 +316,8 @@ export default function createListComponent({
     render() {
       const {
         children,
+        before,
+        after,
         className,
         direction,
         height,
@@ -377,6 +385,7 @@ export default function createListComponent({
             ...style,
           },
         },
+        getSlot(before),
         createElement(innerElementType || innerTagName || 'div', {
           children: items,
           ref: innerRef,
@@ -385,7 +394,8 @@ export default function createListComponent({
             pointerEvents: isScrolling ? 'none' : undefined,
             width: isHorizontal ? estimatedTotalSize : '100%',
           },
-        })
+        }),
+        getSlot(after),
       );
     }
 

--- a/src/getSlot.js
+++ b/src/getSlot.js
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+export type SlotCallback = () => ReactNode;
+
+export const getSlot = (value: SlotCallback | ReactNode): ReactNode =>
+  typeof value === 'function' ? value() : value;


### PR DESCRIPTION
Hi, I could like to add two render hooks, which is `before` and `after`, to been able to render elements before or after the inner element.

the use case I can give is, that render a cursor element that can scroll beside with the inner element.

and there is a [feature request](https://github.com/bvaughn/react-window/issues/701) about this MR.

thanks.