### PR TITLE
Remove type check for js and refactor code

### DIFF
--- a/website/src/utils.js
+++ b/website/src/utils.js
@@ -1,7 +1,4 @@
-export function fillArray(length, fillFunction): Array {
-  const array = new Array(length);
-  for (let i = 0; i < length; i++) {
-    array[i] = fillFunction(i);
-  }
-  return array;
-}
+// Create a new array with the length and fill it with the fillFunction
+export const fillArray = (length, fillFunction) => {
+  return Array.from({ length }, (_, i) => fillFunction(i));
+};


### PR DESCRIPTION
<img width="430" alt="Screenshot 2023-06-06 at 12 19 43 AM" src="https://github.com/bvaughn/react-window/assets/11611776/01a93aba-cc80-46f4-bd0e-c818f4868268">

We were using type checks of `utils` file and was throwing the following `lint` error
```
Type annotations can only be used in TypeScript files
```

Also, I have refactored the code little bit to simplify with `Array.from` since we have `length` param