### PR TITLE
use scrollEnd event to detect scrollend where possible

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -663,12 +663,15 @@ export default function createListComponent({
     };
 
     _resetIsScrollingDebounced = () => {
-      if (this.props.manualScrollEndDetection === true) {
+      const outerElementIsCustomElement = this._outerElementIsCustomElement();
+      if (
+        this.props.manualScrollEndDetection === true &&
+        outerElementIsCustomElement
+      ) {
         return;
       }
-      const useScrollEndEventInsteadOfTimer =
-        scrollEndIsSupported && !this._outerElementIsCustomElement();
-      if (useScrollEndEventInsteadOfTimer) {
+
+      if (scrollEndIsSupported && !outerElementIsCustomElement) {
         return;
       }
 

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -79,7 +79,7 @@ export type Props<T> = {|
   overscanCount: number,
   style?: Object,
   useIsScrolling: boolean,
-  manualScrollEndDetection?: boolean,
+  useScrollEndEvent?: boolean,
   width: number | string,
 |};
 
@@ -172,7 +172,7 @@ export default function createListComponent({
       layout: 'vertical',
       overscanCount: 2,
       useIsScrolling: false,
-      manualScrollEndDetection: false,
+      useScrollEndEvent: false,
     };
 
     state: State = {
@@ -330,7 +330,7 @@ export default function createListComponent({
         outerTagName,
         style,
         useIsScrolling,
-        manualScrollEndDetection,
+        useScrollEndEvent,
         width,
       } = this.props;
       const { isScrolling } = this.state;
@@ -386,8 +386,11 @@ export default function createListComponent({
       // 'onScrollEnd' doesn't exist yet in react for regular html elements.
       // we therefore only supply it if the outer element is a custom element
       // and the user will handle it manually.
-      const outerElementIsCustomElement = this._outerElementIsCustomElement();
-      if (manualScrollEndDetection && outerElementIsCustomElement) {
+      if (
+        scrollEndIsSupported &&
+        useScrollEndEvent &&
+        this._outerElementIsCustomElement()
+      ) {
         outerElementProps.onScrollEnd = this._onScrollEnd;
       }
       return createElement(
@@ -664,15 +667,13 @@ export default function createListComponent({
 
     _resetIsScrollingDebounced = () => {
       const outerElementIsCustomElement = this._outerElementIsCustomElement();
-      if (
-        this.props.manualScrollEndDetection === true &&
-        outerElementIsCustomElement
-      ) {
-        return;
-      }
-
-      if (scrollEndIsSupported && !outerElementIsCustomElement) {
-        return;
+      if (scrollEndIsSupported) {
+        if (
+          (outerElementIsCustomElement && this.props.useScrollEndEvent) ||
+          !outerElementIsCustomElement
+        ) {
+          return;
+        }
       }
 
       if (this._resetIsScrollingTimeoutId !== null) {

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -386,6 +386,8 @@ export default function createListComponent({
       // 'onScrollEnd' doesn't exist yet in react for regular html elements.
       // we therefore only supply it if the outer element is a custom element
       // and the user will handle it manually.
+      // This property is not set inline because even if it is set to undefined,
+      // react would still warn that it is an unknown property.
       if (
         scrollEndIsSupported &&
         useScrollEndEvent &&
@@ -666,8 +668,8 @@ export default function createListComponent({
     };
 
     _resetIsScrollingDebounced = () => {
-      const outerElementIsCustomElement = this._outerElementIsCustomElement();
       if (scrollEndIsSupported) {
+        const outerElementIsCustomElement = this._outerElementIsCustomElement();
         if (
           (outerElementIsCustomElement && this.props.useScrollEndEvent) ||
           !outerElementIsCustomElement

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -388,6 +388,8 @@ export default function createListComponent({
       // and the user will handle it manually.
       // This property is not set inline because even if it is set to undefined,
       // react would still warn that it is an unknown property.
+      // scrollEnd will probably be available properly in react 19. See
+      // https://github.com/facebook/react/pull/26789
       if (
         scrollEndIsSupported &&
         useScrollEndEvent &&
@@ -661,6 +663,8 @@ export default function createListComponent({
 
       // 'onScrollEnd' doesn't exist yet in react for regular html elements.
       // we therefore attach the event listener manually.
+      // scrollEnd will probably be available properly in react 19. See
+      // https://github.com/facebook/react/pull/26789
       const outerElementIsCustomElement = this._outerElementIsCustomElement();
       if (scrollEndIsSupported && !outerElementIsCustomElement) {
         ref.addEventListener('scrollend', this._onScrollEnd);

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -666,6 +666,11 @@ export default function createListComponent({
       if (this.props.manualScrollEndDetection === true) {
         return;
       }
+      const useScrollEndEventInsteadOfTimer =
+        scrollEndIsSupported && !this._outerElementIsCustomElement();
+      if (useScrollEndEventInsteadOfTimer) {
+        return;
+      }
 
       if (this._resetIsScrollingTimeoutId !== null) {
         cancelTimeout(this._resetIsScrollingTimeoutId);


### PR DESCRIPTION
**Overview**

On every scroll event, animationFrame-based timers are installed and uninstalled to find the moment the user stopped scrolling, so `pointer-events: none` can be removed.

**This installing and uninstalling of animationFrame-callbacks costs time.** Not that much, but measurable on slow devices, and for most modern browsers, a better alternative exists: The [scrollend](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollend_event)-event. (also see [this chrome developers blogpost](https://developer.chrome.com/blog/scrollend-a-new-javascript-event))

This PR aims to replace the timer with the scrollEnd-event where possible.
- For native HTML-Elements, that is the case when the browser supports it
- For custom OuterElements, that is the case when the browser supports it and the user triggers a new `onScrollEnd` event.

---
**Changed default**

To not break existing custom OuterElements, that onScrollEnd is only supplied and used when the user sets the `useScrollEndEvent`-property and the browser supports the event.
If that property is set however, the user has to call the onScrollEnd when appropriate (just like the onScroll-event)

The way it's currently implemented, these changes switch the default scroll-end detection (for non-custom outer-elements) to the scrollend-event if possible. If that is to drastic, we could change it so that the scrollEnd event is only ever used if `useScrollEnd === true`.

---
**About this PR**

I'm not to deep in the codebase, so some details of the implementation might not be optimal and i would be thankful for feedback.

~~I will update the docs soon, which is why this is a draft-pr for now, but the code is done as long as there is no feedback.~~
I will still try to update the docs soon, but the setup for the website requirs some older versions of node and some dependencies that are not in the package.json, so updating the docs isn't as simple as i thought.

There is also at least one edge-cases that is not covered (yet!): `onScroll` being called without the user scrolling. For example when the user has scrolled far down and then the number of items gets reduced. This seemingly triggers a scroll, but no scrollEnd
*(reminder for myself: maybe the event has info if it was triggered by the mouse/wheel/touch. if that is absent, maybe don't set `isScrolling` to true)*

---
**Performance**

Here is scrolling through a extreme simple 5000 items list:
(chrome with 6x slowdown on M2 Max)
```jsx
import { FixedSizeList as List } from "react-window";

const Row = ({ index, style }) => (
  <div style={style}>
    Row {index}
  </div>
);

function App() {
  return (
    <List
      height={300}
      itemCount={5000}
      itemSize={35}
      width={300}
    >
      {Row}
    </List>
  )
}

export default App
```
| with animationframe-timer | with scrollend-event |
| --- | --- |
| ![full_old](https://github.com/bvaughn/react-window/assets/20770029/fd22fb54-3327-4e24-bdff-58550444dd10) | ![full_new](https://github.com/bvaughn/react-window/assets/20770029/931c84a3-8606-4027-9f53-6b994c3abefa) |
| ![details_old](https://github.com/bvaughn/react-window/assets/20770029/bfdfd686-d035-46ac-a755-c27867d66f2c) | ![details_new](https://github.com/bvaughn/react-window/assets/20770029/f910e386-4c28-46cc-b60f-6881c738f2ba) |

