### PR TITLE
Remove Style attribute: pointer-events

### DIFF
--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -382,7 +382,6 @@ export default function createListComponent({
           ref: innerRef,
           style: {
             height: isHorizontal ? '100%' : estimatedTotalSize,
-            pointerEvents: isScrolling ? 'none' : undefined,
             width: isHorizontal ? estimatedTotalSize : '100%',
           },
         })


### PR DESCRIPTION
Solve the issue where events cannot be triggered during scrolling, but it's unclear what the purpose of this style attribute is here.

#736 