### PR TITLE
add React 19 compatibility layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-window",
-  "version": "1.8.11",
+  "version": "1.8.12",
   "description": "React components for efficiently rendering large, scrollable lists and tabular data",
   "author": "Brian Vaughn <brian.david.vaughn@gmail.com> (https://github.com/bvaughn/)",
   "contributors": [

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -1,7 +1,7 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
-import { createElement, PureComponent } from 'react';
+import { createElement, PureComponent } from './react19-compat';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 

--- a/src/createGridComponent.js
+++ b/src/createGridComponent.js
@@ -1,6 +1,7 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
+import React from 'react';
 import { createElement, PureComponent } from './react19-compat';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -2,7 +2,7 @@
 
 import memoizeOne from 'memoize-one';
 import React from 'react';
-import { createElement } from './react19-compat';
+import { createElement, PureComponent } from './react19-compat';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 
@@ -157,7 +157,7 @@ export default function createListComponent({
   shouldResetStyleCacheOnItemSizeChange: boolean,
   validateProps: ValidateProps,
 |}) {
-  return class List<T> extends React.Component<Props<T>, State> {
+  return class List<T> extends PureComponent<Props<T>, State> {
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -1,6 +1,7 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
+import React from 'react';
 import { createElement } from './react19-compat';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';

--- a/src/createListComponent.js
+++ b/src/createListComponent.js
@@ -1,7 +1,7 @@
 // @flow
 
 import memoizeOne from 'memoize-one';
-import { createElement, PureComponent } from 'react';
+import { createElement } from './react19-compat';
 import { cancelTimeout, requestTimeout } from './timer';
 import { getScrollbarSize, getRTLOffsetType } from './domHelpers';
 
@@ -156,7 +156,7 @@ export default function createListComponent({
   shouldResetStyleCacheOnItemSizeChange: boolean,
   validateProps: ValidateProps,
 |}) {
-  return class List<T> extends PureComponent<Props<T>, State> {
+  return class List<T> extends React.Component<Props<T>, State> {
     _instanceProps: any = initInstanceProps(this.props, this);
     _outerRef: ?HTMLDivElement;
     _resetIsScrollingTimeoutId: TimeoutID | null = null;

--- a/src/react19-compat.js
+++ b/src/react19-compat.js
@@ -1,0 +1,37 @@
+// React 19 compatibility layer
+import React from 'react';
+
+// In React 19, PureComponent is removed, this is a functional component
+// that mimics PureComponent behavior
+export class PureComponent extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return !this.shallowEqual(this.props, nextProps) || !this.shallowEqual(this.state, nextState);
+  }
+
+  shallowEqual(objA, objB) {
+    if (objA === objB) {
+      return true;
+    }
+
+    if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+      return false;
+    }
+
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    for (let i = 0; i < keysA.length; i++) {
+      if (!objB.hasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+export const { createElement } = React; 

--- a/src/react19-compat.js
+++ b/src/react19-compat.js
@@ -5,7 +5,10 @@ import React from 'react';
 // that mimics PureComponent behavior
 export class PureComponent extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
-    return !this.shallowEqual(this.props, nextProps) || !this.shallowEqual(this.state, nextState);
+    return (
+      !this.shallowEqual(this.props, nextProps) ||
+      !this.shallowEqual(this.state, nextState)
+    );
   }
 
   shallowEqual(objA, objB) {
@@ -13,7 +16,12 @@ export class PureComponent extends React.Component {
       return true;
     }
 
-    if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
+    if (
+      typeof objA !== 'object' ||
+      objA === null ||
+      typeof objB !== 'object' ||
+      objB === null
+    ) {
       return false;
     }
 
@@ -34,4 +42,4 @@ export class PureComponent extends React.Component {
   }
 }
 
-export const { createElement } = React; 
+export const { createElement } = React;


### PR DESCRIPTION
React 19 has completely removed class components, including PureComponent. In react 19+ projects getting error: `Cannot read properties of undefined (reading 'PureComponent’)` was occurring because the library was trying to import PureComponent from React, which no longer exists in React 19