### PR TITLE
Merge parts of dynamic size branch

### DIFF
--- a/lib/components/grid/Grid.test.tsx
+++ b/lib/components/grid/Grid.test.tsx
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EMPTY_OBJECT } from "../../../src/constants";
 import {
   disableResizeObserverForCurrentTest,
-  simulateUnsupportedEnvironmentForTest,
-  updateMockResizeObserver
+  setDefaultElementSize,
+  simulateUnsupportedEnvironmentForTest
 } from "../../utils/test/mockResizeObserver";
 import { Grid } from "./Grid";
 import type { CellComponentProps, GridImperativeAPI } from "./types";
@@ -36,7 +36,7 @@ describe("Grid", () => {
   beforeEach(() => {
     CellComponent.mockReset();
 
-    updateMockResizeObserver(new DOMRect(0, 0, 100, 40));
+    setDefaultElementSize({ height: 40, width: 100 });
 
     mountedCells = new Map();
   });
@@ -273,7 +273,6 @@ describe("Grid", () => {
 
     const items = screen.queryAllByRole("gridcell");
     expect(items).toHaveLength(8);
-    // TODO
   });
 
   test("should call onCellsRendered", () => {

--- a/lib/components/grid/Grid.tsx
+++ b/lib/components/grid/Grid.tsx
@@ -48,7 +48,7 @@ export function Grid<
   const isRtl = useIsRtl(element, dir);
 
   const {
-    getCellBounds: getColumnBounds,
+    cachedBounds: cachedColumnBounds,
     getEstimatedSize: getEstimatedWidth,
     startIndexOverscan: columnStartIndexOverscan,
     startIndexVisible: columnStartIndexVisible,
@@ -69,7 +69,7 @@ export function Grid<
   });
 
   const {
-    getCellBounds: getRowBounds,
+    cachedBounds: cachedRowBounds,
     getEstimatedSize: getEstimatedHeight,
     startIndexOverscan: rowStartIndexOverscan,
     startIndexVisible: rowStartIndexVisible,
@@ -220,7 +220,8 @@ export function Grid<
         rowIndex <= rowStopIndexOverscan;
         rowIndex++
       ) {
-        const rowBounds = getRowBounds(rowIndex);
+        const rowBounds = cachedRowBounds.getItemBounds(rowIndex);
+        const rowOffset = rowBounds?.scrollOffset;
 
         const columns: ReactNode[] = [];
 
@@ -229,7 +230,8 @@ export function Grid<
           columnIndex <= columnStopIndexOverscan;
           columnIndex++
         ) {
-          const columnBounds = getColumnBounds(columnIndex);
+          const columnBounds = cachedColumnBounds.getItemBounds(columnIndex);
+          const columnOffset = columnBounds?.scrollOffset;
 
           columns.push(
             <CellComponent
@@ -245,9 +247,9 @@ export function Grid<
                 position: "absolute",
                 left: isRtl ? undefined : 0,
                 right: isRtl ? 0 : undefined,
-                transform: `translate(${isRtl ? -columnBounds.scrollOffset : columnBounds.scrollOffset}px, ${rowBounds.scrollOffset}px)`,
-                height: rowBounds.size,
-                width: columnBounds.size
+                transform: `translate(${isRtl ? -columnOffset : columnOffset}px, ${rowOffset}px)`,
+                height: rowBounds?.size,
+                width: columnBounds?.size
               }}
             />
           );
@@ -262,13 +264,13 @@ export function Grid<
     }
     return children;
   }, [
+    cachedColumnBounds,
+    cachedRowBounds,
     CellComponent,
     cellProps,
     columnCount,
     columnStartIndexOverscan,
     columnStopIndexOverscan,
-    getColumnBounds,
-    getRowBounds,
     isRtl,
     rowCount,
     rowStartIndexOverscan,

--- a/lib/components/list/List.test.tsx
+++ b/lib/components/list/List.test.tsx
@@ -2,10 +2,12 @@ import { act, render, screen } from "@testing-library/react";
 import { createRef, useLayoutEffect } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EMPTY_OBJECT } from "../../../src/constants";
+import { assert } from "../../utils/assert";
 import {
   disableResizeObserverForCurrentTest,
-  simulateUnsupportedEnvironmentForTest,
-  updateMockResizeObserver
+  setDefaultElementSize,
+  setElementSize,
+  simulateUnsupportedEnvironmentForTest
 } from "../../utils/test/mockResizeObserver";
 import { List } from "./List";
 import { type ListImperativeAPI, type RowComponentProps } from "./types";
@@ -34,7 +36,7 @@ describe("List", () => {
   beforeEach(() => {
     RowComponent.mockReset();
 
-    updateMockResizeObserver(new DOMRect(0, 0, 50, 100));
+    setDefaultElementSize({ height: 100, width: 50 });
 
     mountedRows = new Map();
   });
@@ -56,7 +58,7 @@ describe("List", () => {
   test("should render enough rows to fill the available height", () => {
     const onResize = vi.fn();
 
-    render(
+    const { container } = render(
       <List
         onResize={onResize}
         overscanCount={0}
@@ -85,7 +87,14 @@ describe("List", () => {
     );
 
     act(() => {
-      updateMockResizeObserver(new DOMRect(0, 0, 50, 75));
+      const listElement = container.querySelector<HTMLElement>('[role="list"]');
+      assert(listElement !== null);
+
+      setElementSize({
+        element: listElement,
+        height: 75,
+        width: 50
+      });
     });
 
     items = screen.queryAllByRole("listitem");
@@ -107,7 +116,7 @@ describe("List", () => {
   });
 
   test("should render enough rows to fill the available height with overscan", () => {
-    render(
+    const { container } = render(
       <List
         overscanCount={2}
         rowCount={100}
@@ -123,7 +132,14 @@ describe("List", () => {
     expect(items[5]).toHaveTextContent("Row 5");
 
     act(() => {
-      updateMockResizeObserver(new DOMRect(0, 0, 50, 75));
+      const listElement = container.querySelector<HTMLElement>('[role="list"]');
+      assert(listElement !== null);
+
+      setElementSize({
+        element: listElement,
+        height: 75,
+        width: 50
+      });
     });
 
     items = screen.queryAllByRole("listitem");

--- a/lib/components/list/List.tsx
+++ b/lib/components/list/List.tsx
@@ -5,6 +5,7 @@ import {
   useImperativeHandle,
   useMemo,
   useState,
+  type CSSProperties,
   type ReactNode
 } from "react";
 import { useVirtualizer } from "../../core/useVirtualizer";
@@ -41,7 +42,7 @@ export function List<
   const [element, setElement] = useState<HTMLDivElement | null>(null);
 
   const {
-    getCellBounds,
+    cachedBounds,
     getEstimatedSize,
     scrollToIndex,
     startIndexOverscan,
@@ -114,6 +115,13 @@ export function List<
     stopIndexVisible
   ]);
 
+  const hasRowHeight = rowHeight !== undefined;
+
+  const offset =
+    startIndexOverscan >= 0
+      ? cachedBounds.getItemBounds(startIndexOverscan).scrollOffset
+      : 0;
+
   const rows = useMemo(() => {
     const children: ReactNode[] = [];
     if (rowCount > 0) {
@@ -122,7 +130,15 @@ export function List<
         index <= stopIndexOverscan;
         index++
       ) {
-        const bounds = getCellBounds(index);
+        const bounds = cachedBounds.getItemBounds(index);
+        const style: CSSProperties = {
+          height: hasRowHeight ? bounds.size : undefined,
+          width: "100%"
+        };
+
+        if (index === startIndexOverscan) {
+          style.marginTop = `${offset}px`;
+        }
 
         children.push(
           <RowComponent
@@ -134,13 +150,7 @@ export function List<
             }}
             key={index}
             index={index}
-            style={{
-              position: "absolute",
-              left: 0,
-              transform: `translateY(${bounds.scrollOffset}px)`,
-              height: bounds.size,
-              width: "100%"
-            }}
+            style={style}
           />
         );
       }
@@ -148,7 +158,9 @@ export function List<
     return children;
   }, [
     RowComponent,
-    getCellBounds,
+    cachedBounds,
+    hasRowHeight,
+    offset,
     rowCount,
     rowProps,
     startIndexOverscan,

--- a/lib/core/createCachedBounds.test.ts
+++ b/lib/core/createCachedBounds.test.ts
@@ -62,6 +62,8 @@ describe("createCachedBounds", () => {
 
     expect(cachedBounds.size).toBe(0);
 
+    expect(cachedBounds.getEstimatedSize()).toEqual(0);
+
     expect(() => {
       cachedBounds.getItemBounds(1);
     }).toThrow("Invalid index 1");

--- a/lib/core/createCachedBounds.test.ts
+++ b/lib/core/createCachedBounds.test.ts
@@ -13,14 +13,14 @@ describe("createCachedBounds", () => {
     expect(itemSize).not.toHaveBeenCalled();
     expect(cachedBounds.size).toBe(0);
 
-    expect(cachedBounds.get(2)).toEqual({
+    expect(cachedBounds.getItemBounds(2)).toEqual({
       scrollOffset: 21,
       size: 12
     });
     expect(itemSize).toHaveBeenCalledTimes(3);
     expect(cachedBounds.size).toBe(3);
 
-    expect(cachedBounds.get(3)).toEqual({
+    expect(cachedBounds.getItemBounds(3)).toEqual({
       scrollOffset: 33,
       size: 13
     });
@@ -40,13 +40,13 @@ describe("createCachedBounds", () => {
     expect(itemSize).not.toHaveBeenCalled();
     expect(cachedBounds.size).toBe(0);
 
-    cachedBounds.get(9);
+    cachedBounds.getItemBounds(9);
 
     expect(itemSize).toHaveBeenCalledTimes(10);
     expect(cachedBounds.size).toBe(10);
 
     for (let index = 0; index < 10; index++) {
-      cachedBounds.get(index);
+      cachedBounds.getItemBounds(index);
     }
 
     expect(itemSize).toHaveBeenCalledTimes(10);
@@ -63,7 +63,7 @@ describe("createCachedBounds", () => {
     expect(cachedBounds.size).toBe(0);
 
     expect(() => {
-      cachedBounds.get(1);
+      cachedBounds.getItemBounds(1);
     }).toThrow("Invalid index 1");
   });
 });

--- a/lib/core/createCachedBounds.ts
+++ b/lib/core/createCachedBounds.ts
@@ -14,12 +14,13 @@ export function createCachedBounds<Props extends object>({
 
   const api = {
     getEstimatedSize() {
-      const lastBounds = cache.get(cache.size - 1);
-      if (lastBounds) {
-        return (lastBounds.scrollOffset + lastBounds.size) / cache.size;
+      if (itemCount === 0) {
+        return 0;
       } else {
-        const firstBounds = api.getItemBounds(0);
-        return firstBounds.size * itemCount;
+        const bounds = api.getItemBounds(cache.size === 0 ? 0 : cache.size - 1);
+        assert(bounds, "Unexpected bounds cache miss");
+
+        return (bounds.scrollOffset + bounds.size) / cache.size;
       }
     },
     getItemBounds(index: number) {
@@ -67,9 +68,6 @@ export function createCachedBounds<Props extends object>({
       );
 
       return bounds;
-    },
-    hasItemBounds(index: number) {
-      return cache.has(index);
     },
     get size() {
       return cache.size;

--- a/lib/core/getEstimatedSize.test.ts
+++ b/lib/core/getEstimatedSize.test.ts
@@ -21,6 +21,20 @@ describe("getEstimatedSize", () => {
       ).toBe(0);
     });
 
+    test("should return an estimate based on the first row if no sizes have yet been measured", () => {
+      expect(
+        getEstimatedSize({
+          cachedBounds: createCachedBounds({
+            itemCount: 1,
+            itemProps: EMPTY_OBJECT,
+            itemSize
+          }),
+          itemCount: 1,
+          itemSize
+        })
+      ).toBe(10);
+    });
+
     test("should return an average size based on the first item if no measurements have been taken", () => {
       expect(
         getEstimatedSize({

--- a/lib/core/getEstimatedSize.test.ts
+++ b/lib/core/getEstimatedSize.test.ts
@@ -41,7 +41,7 @@ describe("getEstimatedSize", () => {
         itemProps: EMPTY_OBJECT,
         itemSize
       });
-      cachedBounds.get(4);
+      cachedBounds.getItemBounds(4);
 
       expect(
         getEstimatedSize({
@@ -59,7 +59,7 @@ describe("getEstimatedSize", () => {
         itemSize
       });
 
-      cachedBounds.get(9);
+      cachedBounds.getItemBounds(9);
 
       expect(
         getEstimatedSize({

--- a/lib/core/getEstimatedSize.ts
+++ b/lib/core/getEstimatedSize.ts
@@ -12,17 +12,22 @@ export function getEstimatedSize<Props extends object>({
 }) {
   if (itemCount === 0) {
     return 0;
-  } else if (typeof itemSize === "number") {
-    return itemCount * itemSize;
   } else {
-    const bounds = cachedBounds.get(
-      cachedBounds.size === 0 ? 0 : cachedBounds.size - 1
-    );
-    assert(bounds !== undefined, "Unexpected bounds cache miss");
+    switch (typeof itemSize) {
+      case "function": {
+        const bounds = cachedBounds.getItemBounds(
+          cachedBounds.size === 0 ? 0 : cachedBounds.size - 1
+        );
+        assert(bounds !== undefined, "Unexpected bounds cache miss");
 
-    const averageItemSize =
-      (bounds.scrollOffset + bounds.size) / cachedBounds.size;
+        const averageItemSize =
+          (bounds.scrollOffset + bounds.size) / cachedBounds.size;
 
-    return itemCount * averageItemSize;
+        return itemCount * averageItemSize;
+      }
+      case "number": {
+        return itemCount * itemSize;
+      }
+    }
   }
 }

--- a/lib/core/getEstimatedSize.ts
+++ b/lib/core/getEstimatedSize.ts
@@ -1,5 +1,4 @@
 import type { CachedBounds, SizeFunction } from "./types";
-import { assert } from "../utils/assert";
 
 export function getEstimatedSize<Props extends object>({
   cachedBounds,
@@ -18,7 +17,6 @@ export function getEstimatedSize<Props extends object>({
         const bounds = cachedBounds.getItemBounds(
           cachedBounds.size === 0 ? 0 : cachedBounds.size - 1
         );
-        assert(bounds !== undefined, "Unexpected bounds cache miss");
 
         const averageItemSize =
           (bounds.scrollOffset + bounds.size) / cachedBounds.size;

--- a/lib/core/getOffsetForIndex.ts
+++ b/lib/core/getOffsetForIndex.ts
@@ -1,5 +1,4 @@
 import type { Align } from "../types";
-import { assert } from "../utils/assert";
 import { getEstimatedSize } from "./getEstimatedSize";
 import type { CachedBounds, SizeFunction } from "./types";
 
@@ -25,12 +24,8 @@ export function getOffsetForIndex<Props extends object>({
     itemCount,
     itemSize
   });
-  if (estimatedTotalSize === undefined) {
-    return 0;
-  }
 
   const bounds = cachedBounds.getItemBounds(index);
-  assert(bounds, `Unexpected cache miss for index ${index}`);
 
   const maxOffset = Math.max(
     0,

--- a/lib/core/getOffsetForIndex.ts
+++ b/lib/core/getOffsetForIndex.ts
@@ -1,4 +1,5 @@
 import type { Align } from "../types";
+import { assert } from "../utils/assert";
 import { getEstimatedSize } from "./getEstimatedSize";
 import type { CachedBounds, SizeFunction } from "./types";
 
@@ -24,8 +25,13 @@ export function getOffsetForIndex<Props extends object>({
     itemCount,
     itemSize
   });
+  if (estimatedTotalSize === undefined) {
+    return 0;
+  }
 
-  const bounds = cachedBounds.get(index);
+  const bounds = cachedBounds.getItemBounds(index);
+  assert(bounds, `Unexpected cache miss for index ${index}`);
+
   const maxOffset = Math.max(
     0,
     Math.min(estimatedTotalSize - containerSize, bounds.scrollOffset)

--- a/lib/core/getStartStopIndices.ts
+++ b/lib/core/getStartStopIndices.ts
@@ -25,11 +25,14 @@ export function getStartStopIndices({
   let startIndexOverscan = 0;
   let stopIndexOverscan = -1;
   let currentIndex = 0;
+  let currentOffset = 0;
 
   while (currentIndex < maxIndex) {
-    const bounds = cachedBounds.get(currentIndex);
+    const bounds = cachedBounds.getItemBounds(currentIndex);
 
-    if (bounds.scrollOffset + bounds.size > containerScrollOffset) {
+    currentOffset = bounds.scrollOffset + bounds.size;
+
+    if (currentOffset > containerScrollOffset) {
       break;
     }
 
@@ -40,12 +43,11 @@ export function getStartStopIndices({
   startIndexOverscan = Math.max(0, startIndexVisible - overscanCount);
 
   while (currentIndex < maxIndex) {
-    const bounds = cachedBounds.get(currentIndex);
+    const bounds = cachedBounds.getItemBounds(currentIndex);
 
-    if (
-      bounds.scrollOffset + bounds.size >=
-      containerScrollOffset + containerSize
-    ) {
+    currentOffset = bounds.scrollOffset + bounds.size;
+
+    if (currentOffset >= containerScrollOffset + containerSize) {
       break;
     }
 

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -6,7 +6,6 @@ export type Bounds = {
 export type CachedBounds = {
   getEstimatedSize(): number;
   getItemBounds(index: number): Bounds;
-  hasItemBounds(index: number): boolean;
   size: number;
 };
 

--- a/lib/core/types.ts
+++ b/lib/core/types.ts
@@ -4,8 +4,9 @@ export type Bounds = {
 };
 
 export type CachedBounds = {
-  get(index: number): Bounds;
-  set(index: number, bounds: Bounds): void;
+  getEstimatedSize(): number;
+  getItemBounds(index: number): Bounds;
+  hasItemBounds(index: number): boolean;
   size: number;
 };
 

--- a/lib/core/useCachedBounds.test.ts
+++ b/lib/core/useCachedBounds.test.ts
@@ -4,7 +4,7 @@ import { EMPTY_OBJECT } from "../../src/constants";
 import { useCachedBounds } from "./useCachedBounds";
 
 describe("useCachedBounds", () => {
-  test("should cache the CachedBounds unless props change", () => {
+  test("should memoize CachedBounds value unless props change", () => {
     const { result, rerender } = renderHook(
       (props?: Partial<Parameters<typeof useCachedBounds>>[0]) =>
         useCachedBounds({

--- a/lib/core/useVirtualizer.test.ts
+++ b/lib/core/useVirtualizer.test.ts
@@ -1,57 +1,78 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, test } from "vitest";
 import { EMPTY_OBJECT, NOOP_FUNCTION } from "../../src/constants";
-import { updateMockResizeObserver } from "../utils/test/mockResizeObserver";
+import {
+  setDefaultElementSize,
+  setElementSizeFunction
+} from "../utils/test/mockResizeObserver";
 import { useVirtualizer } from "./useVirtualizer";
 
 describe("useVirtualizer", () => {
-  const DEFAULT_ARGS: Parameters<typeof useVirtualizer>[0] = {
-    containerElement: document.body,
-    defaultContainerSize: 100,
-    direction: "vertical",
-    itemCount: 25,
-    itemProps: EMPTY_OBJECT,
-    itemSize: 25,
-    onResize: NOOP_FUNCTION,
-    overscanCount: 0
-  };
+  type Params = Parameters<typeof useVirtualizer>[0];
 
+  function testHelper(config: Partial<Params> = {}) {
+    const containerElement = document.createElement("div");
+    containerElement.setAttribute("role", "list");
+
+    const args: Params = {
+      containerElement,
+      defaultContainerSize: 100,
+      direction: "vertical",
+      itemCount: 25,
+      itemProps: EMPTY_OBJECT,
+      itemSize: 25,
+      onResize: NOOP_FUNCTION,
+      overscanCount: 0,
+      ...config
+    };
+
+    for (let index = 0; index < args.itemCount; index++) {
+      const element = document.createElement("div");
+      containerElement.appendChild(element);
+    }
+
+    return renderHook(() => useVirtualizer(args));
+  }
   beforeEach(() => {
-    updateMockResizeObserver(new DOMRect(0, 0, 50, 100));
+    setDefaultElementSize({ height: 100, width: 50 });
+
+    setElementSizeFunction((element) => {
+      if (element.getAttribute("role") === "list") {
+        return new DOMRect(0, 0, 50, 100);
+      } else {
+        return new DOMRect(0, 0, 50, 25);
+      }
+    });
   });
 
-  describe("getCellBounds", () => {
+  describe("cachedBounds", () => {
     test("itemSize type: number", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize: 25
-        })
-      );
-      expect(result.current.getCellBounds(0)).toEqual({
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize: 25
+      });
+
+      expect(result.current.cachedBounds.getItemBounds(0)).toEqual({
         scrollOffset: 0,
         size: 25
       });
-      expect(result.current.getCellBounds(24)).toEqual({
+      expect(result.current.cachedBounds.getItemBounds(24)).toEqual({
         scrollOffset: 600,
         size: 25
       });
     });
 
     test("itemSize type: string", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize: "50%"
-        })
-      );
-      expect(result.current.getCellBounds(0)).toEqual({
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize: "50%"
+      });
+
+      expect(result.current.cachedBounds.getItemBounds(0)).toEqual({
         scrollOffset: 0,
         size: 50
       });
-      expect(result.current.getCellBounds(24)).toEqual({
+      expect(result.current.cachedBounds.getItemBounds(24)).toEqual({
         scrollOffset: 1200,
         size: 50
       });
@@ -60,19 +81,17 @@ describe("useVirtualizer", () => {
     test("itemSize type: function", () => {
       const itemSize = (index: number) => 20 + index * 20;
 
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemCount: 10,
-          itemSize
-        })
-      );
-      expect(result.current.getCellBounds(0)).toEqual({
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemCount: 10,
+        itemSize
+      });
+
+      expect(result.current.cachedBounds.getItemBounds(0)).toEqual({
         scrollOffset: 0,
         size: 20
       });
-      expect(result.current.getCellBounds(9)).toEqual({
+      expect(result.current.cachedBounds.getItemBounds(9)).toEqual({
         scrollOffset: 900,
         size: 200
       });
@@ -81,61 +100,52 @@ describe("useVirtualizer", () => {
 
   describe("getEstimatedSize", () => {
     test("itemSize type: number", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize: 25
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize: 25
+      });
+
       expect(result.current.getEstimatedSize()).toBe(625);
     });
 
     test("itemSize type: string", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize: "50%"
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize: "50%"
+      });
+
       expect(result.current.getEstimatedSize()).toBe(1250);
     });
 
     test("itemSize type: function", () => {
       const itemSize = (index: number) => 20 + index * 20;
 
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemCount: 10,
-          itemSize
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemCount: 10,
+        itemSize
+      });
 
       // Actual size is 1,100
       // Based on the rows measured so far, the estimated size is 400
       expect(result.current.getEstimatedSize()).toBe(400);
 
       // Finish measuring the rows and the actual size should be returned now
-      result.current.getCellBounds(9);
+      result.current.cachedBounds.getItemBounds(9);
       expect(result.current.getEstimatedSize()).toBe(1100);
     });
   });
 
-  // scrollToIndex is mostly covered by getOffsetForIndex tests
+  // The specific scroll index ranges are mostly covered by getOffsetForIndex tests
 
   describe("startIndex/stopIndex", () => {
     test("itemSize type: number", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize: 25,
-          overscanCount: 2
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize: 25,
+        overscanCount: 2
+      });
+
       expect(result.current.startIndexOverscan).toBe(0);
       expect(result.current.startIndexVisible).toBe(0);
       expect(result.current.stopIndexOverscan).toBe(5);
@@ -143,14 +153,12 @@ describe("useVirtualizer", () => {
     });
 
     test("itemSize type: string", () => {
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          overscanCount: 2,
-          itemSize: "50%"
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        overscanCount: 2,
+        itemSize: "50%"
+      });
+
       expect(result.current.startIndexOverscan).toBe(0);
       expect(result.current.startIndexVisible).toBe(0);
       expect(result.current.stopIndexOverscan).toBe(3);
@@ -160,14 +168,12 @@ describe("useVirtualizer", () => {
     test("itemSize type: function", () => {
       const itemSize = (index: number) => 20 + index * 20;
 
-      const { result } = renderHook(() =>
-        useVirtualizer({
-          ...DEFAULT_ARGS,
-          defaultContainerSize: 100,
-          itemSize,
-          overscanCount: 2
-        })
-      );
+      const { result } = testHelper({
+        defaultContainerSize: 100,
+        itemSize,
+        overscanCount: 2
+      });
+
       expect(result.current.startIndexOverscan).toBe(0);
       expect(result.current.startIndexVisible).toBe(0);
       expect(result.current.stopIndexOverscan).toBe(4);
@@ -180,7 +186,7 @@ describe("useVirtualizer", () => {
       // @ts-expect-error Testing
       HTMLElement.prototype.scrollTo = undefined;
 
-      const { result } = renderHook(() => useVirtualizer(DEFAULT_ARGS));
+      const { result } = testHelper();
 
       result.current.scrollToIndex({ containerScrollOffset: 0, index: 5 });
     });

--- a/lib/core/useVirtualizer.ts
+++ b/lib/core/useVirtualizer.ts
@@ -111,11 +111,6 @@ export function useVirtualizer<Props extends object>({
     itemSize
   });
 
-  const getCellBounds = useCallback(
-    (index: number) => cachedBounds.get(index),
-    [cachedBounds]
-  );
-
   const getEstimatedSize = useCallback(
     () =>
       getEstimatedSizeUtil({
@@ -251,7 +246,7 @@ export function useVirtualizer<Props extends object>({
   );
 
   return {
-    getCellBounds,
+    cachedBounds,
     getEstimatedSize,
     scrollToIndex,
     startIndexOverscan,

--- a/lib/hooks/useResizeObserver.test.ts
+++ b/lib/hooks/useResizeObserver.test.ts
@@ -2,13 +2,14 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, test } from "vitest";
 import {
   simulateUnsupportedEnvironmentForTest,
-  updateMockResizeObserver
+  setDefaultElementSize,
+  setElementSize
 } from "../utils/test/mockResizeObserver";
 import { useResizeObserver } from "./useResizeObserver";
 
 describe("useResizeObserver", () => {
   beforeEach(() => {
-    updateMockResizeObserver({ height: 100, width: 50 });
+    setDefaultElementSize({ height: 100, width: 50 });
   });
 
   test("should use default width/height if disabled", () => {
@@ -34,7 +35,7 @@ describe("useResizeObserver", () => {
 
     act(() => {
       // Updates should be ignored as well
-      updateMockResizeObserver({ height: 25, target: element });
+      setElementSize({ element, height: 25, width: 50 });
     });
 
     expect(result.current).toEqual({
@@ -79,9 +80,10 @@ describe("useResizeObserver", () => {
     });
 
     act(() => {
-      updateMockResizeObserver({
+      setElementSize({
+        element,
         height: 50,
-        target: element
+        width: 50
       });
     });
 
@@ -104,9 +106,10 @@ describe("useResizeObserver", () => {
     );
 
     act(() => {
-      updateMockResizeObserver({
+      setElementSize({
+        element: otherElement,
         height: 50,
-        target: otherElement
+        width: 50
       });
     });
 

--- a/lib/utils/test/mockResizeObserver.ts
+++ b/lib/utils/test/mockResizeObserver.ts
@@ -1,13 +1,50 @@
 import EventEmitter from "node:events";
 
-const emitter = new EventEmitter();
-emitter.setMaxListeners(25);
+type GetDOMRect = (element: HTMLElement) => DOMRectReadOnly | undefined | void;
 
+const emitter = new EventEmitter();
+emitter.setMaxListeners(100);
+
+const elementToDOMRect = new Map<HTMLElement, DOMRect>();
+
+let defaultDomRect: DOMRectReadOnly = new DOMRect(0, 0, 0, 0);
 let disabled: boolean = false;
-let entrySize: DOMRectReadOnly = new DOMRect(0, 0, 0, 0);
+let getDOMRect: GetDOMRect | undefined = undefined;
 
 export function disableResizeObserverForCurrentTest() {
   disabled = true;
+}
+
+export function setDefaultElementSize({
+  height,
+  width
+}: {
+  height: number;
+  width: number;
+}) {
+  defaultDomRect = new DOMRect(0, 0, width, height);
+
+  emitter.emit("change");
+}
+
+export function setElementSizeFunction(value: GetDOMRect) {
+  getDOMRect = value;
+
+  emitter.emit("change");
+}
+
+export function setElementSize({
+  element,
+  height,
+  width
+}: {
+  element: HTMLElement;
+  height: number;
+  width: number;
+}) {
+  elementToDOMRect.set(element, new DOMRect(0, 0, width, height));
+
+  emitter.emit("change", element);
 }
 
 export function simulateUnsupportedEnvironmentForTest() {
@@ -15,90 +52,108 @@ export function simulateUnsupportedEnvironmentForTest() {
   window.ResizeObserver = null;
 }
 
-export function updateMockResizeObserver({
-  height,
-  target,
-  width
-}: {
-  height?: number;
-  target?: HTMLElement;
-  width?: number;
-}): void {
-  entrySize = new DOMRect(
-    0,
-    0,
-    width ?? entrySize.width,
-    height ?? entrySize.height
-  );
-
-  emitter.emit("change", target);
-}
-
 export function mockResizeObserver() {
   disabled = false;
 
   const originalResizeObserver = window.ResizeObserver;
 
-  window.ResizeObserver = class implements ResizeObserver {
-    readonly #callback: ResizeObserverCallback;
-    #disconnected: boolean = false;
-    #elements: Set<HTMLElement> = new Set();
-
-    constructor(callback: ResizeObserverCallback) {
-      this.#callback = callback;
-
-      emitter.addListener("change", this.#onChange);
-    }
-
-    observe(element: HTMLElement) {
-      if (this.#disconnected) {
-        return;
-      }
-
-      this.#elements.add(element);
-      this.#notify(element);
-    }
-
-    unobserve(element: HTMLElement) {
-      this.#elements.delete(element);
-    }
-
-    disconnect() {
-      this.#disconnected = true;
-      this.#elements.clear();
-
-      emitter.removeListener("change", this.#onChange);
-    }
-
-    #notify(target: HTMLElement) {
-      if (disabled) {
-        return;
-      }
-
-      this.#callback(
-        [
-          {
-            borderBoxSize: [],
-            contentBoxSize: [],
-            contentRect: entrySize,
-            devicePixelContentBoxSize: [],
-            target
-          }
-        ],
-        this
-      );
-    }
-
-    #onChange = (target?: HTMLElement) => {
-      if (target) {
-        this.#notify(target);
-      } else {
-        this.#elements.forEach((element) => this.#notify(element));
-      }
-    };
-  };
+  window.ResizeObserver = MockResizeObserver;
 
   return function unmockResizeObserver() {
     window.ResizeObserver = originalResizeObserver;
+
+    defaultDomRect = new DOMRect(0, 0, 0, 0);
+    disabled = false;
+    getDOMRect = undefined;
+
+    elementToDOMRect.clear();
+  };
+}
+
+class MockResizeObserver implements ResizeObserver {
+  readonly #callback: ResizeObserverCallback;
+  #disconnected: boolean = false;
+  #elements: Set<HTMLElement> = new Set();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.#callback = callback;
+
+    emitter.addListener("change", this.#onChange);
+  }
+
+  observe(element: HTMLElement) {
+    if (this.#disconnected) {
+      return;
+    }
+
+    this.#elements.add(element);
+    this.#notify([element]);
+  }
+
+  unobserve(element: HTMLElement) {
+    this.#elements.delete(element);
+  }
+
+  disconnect() {
+    this.#disconnected = true;
+    this.#elements.clear();
+
+    emitter.removeListener("change", this.#onChange);
+  }
+
+  #notify(elements: HTMLElement[]) {
+    if (disabled) {
+      return;
+    }
+
+    const entries = elements.map((element) => {
+      const computedStyle = window.getComputedStyle(element);
+      const writingMode = computedStyle.writingMode;
+
+      let contentRect: DOMRectReadOnly =
+        elementToDOMRect.get(element) ?? defaultDomRect;
+
+      if (getDOMRect) {
+        const contentRectOverride = getDOMRect(element);
+        if (contentRectOverride) {
+          contentRect = contentRectOverride;
+        }
+      }
+
+      let blockSize = 0;
+      let inlineSize = 0;
+      if (writingMode.includes("vertical")) {
+        blockSize = contentRect.width;
+        inlineSize = contentRect.height;
+      } else {
+        blockSize = contentRect.height;
+        inlineSize = contentRect.width;
+      }
+
+      return {
+        borderBoxSize: [
+          {
+            blockSize,
+            inlineSize
+          }
+        ],
+        contentBoxSize: [],
+        contentRect,
+        devicePixelContentBoxSize: [],
+        target: element
+      };
+    });
+
+    this.#callback(entries, this);
+  }
+
+  #onChange = (target?: HTMLElement) => {
+    if (target) {
+      if (this.#elements.has(target)) {
+        this.#notify([target]);
+      }
+    } else {
+      this.#notify(Array.from(this.#elements));
+    }
   };
 }


### PR DESCRIPTION
Merge parts of #830

- Refactor `mockResizeObserver` test util to be more powerful
- `useVirtualizer` hook replaces `getCellBounds` method with `cachedBounds`