### PR TITLE
Fix ResizeObserver being used in the List even when height is provided

### DIFF
--- a/lib/components/grid/Grid.test.tsx
+++ b/lib/components/grid/Grid.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EMPTY_OBJECT } from "../../../src/constants";
 import {
   disableForCurrentTest,
+  simulateUnsupportedEnvironmentForTest,
   updateMockResizeObserver
 } from "../../utils/test/mockResizeObserver";
 import { Grid } from "./Grid";
@@ -578,6 +579,26 @@ describe("Grid", () => {
       }
 
       render(<Test />);
+    });
+
+    test("should not require ResizeObserver if size is provided", () => {
+      const originalResizeObserver = window.ResizeObserver;
+      simulateUnsupportedEnvironmentForTest();
+
+      render(
+        <Grid
+          cellComponent={CellComponent}
+          cellProps={EMPTY_OBJECT}
+          columnCount={100}
+          columnWidth={25}
+          overscanCount={2}
+          rowCount={100}
+          rowHeight={20}
+          style={{ height: 42, width: 84 }}
+        />
+      );
+
+      window.ResizeObserver = originalResizeObserver;
     });
   });
 

--- a/lib/components/grid/Grid.tsx
+++ b/lib/components/grid/Grid.tsx
@@ -57,6 +57,7 @@ export function Grid<
     stopIndexVisible: columnStopIndexVisible
   } = useVirtualizer({
     containerElement: element,
+    containerStyle: style,
     defaultContainerSize: defaultWidth,
     direction: "horizontal",
     isRtl,
@@ -77,6 +78,7 @@ export function Grid<
     stopIndexVisible: rowStopIndexVisible
   } = useVirtualizer({
     containerElement: element,
+    containerStyle: style,
     defaultContainerSize: defaultHeight,
     direction: "vertical",
     itemCount: rowCount,

--- a/lib/components/list/List.test.tsx
+++ b/lib/components/list/List.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EMPTY_OBJECT } from "../../../src/constants";
 import {
   disableForCurrentTest,
+  simulateUnsupportedEnvironmentForTest,
   updateMockResizeObserver
 } from "../../utils/test/mockResizeObserver";
 import { List } from "./List";
@@ -684,6 +685,22 @@ describe("List", () => {
       }
 
       render(<Test />);
+    });
+
+    test("should not require ResizeObserver if height is provided", () => {
+      const originalResizeObserver = window.ResizeObserver;
+      simulateUnsupportedEnvironmentForTest();
+      render(
+        <List
+          overscanCount={0}
+          rowCount={100}
+          rowComponent={RowComponent}
+          rowHeight={25}
+          rowProps={EMPTY_OBJECT}
+          style={{ height: 42 }}
+        />
+      );
+      window.ResizeObserver = originalResizeObserver;
     });
   });
 

--- a/lib/components/list/List.tsx
+++ b/lib/components/list/List.tsx
@@ -50,6 +50,7 @@ export function List<
     stopIndexVisible
   } = useVirtualizer({
     containerElement: element,
+    containerStyle: style,
     defaultContainerSize: defaultHeight,
     direction: "vertical",
     itemCount: rowCount,


### PR DESCRIPTION
The `style` prop isn’t properly forwarded from `List` to `useVirtualizer`, hence it’s `undefined` [here](https://github.com/bvaughn/react-window/blob/0b871d63b8543cbfe46a2d19ad9a7eaf25059070/lib/hooks/useResizeObserver.ts#L24) and the subsequent early return fails. I wrote a quick test and a fix.