### PR TITLE
Export `useCachedBounds` hook as part of public API

### DIFF
--- a/lib/core/useVirtualizer.ts
+++ b/lib/core/useVirtualizer.ts
@@ -5,6 +5,7 @@ import {
   useState,
   type CSSProperties
 } from "react";
+import { useCachedBounds } from "../hooks/useCachedBounds";
 import { useIsomorphicLayoutEffect } from "../hooks/useIsomorphicLayoutEffect";
 import { useResizeObserver } from "../hooks/useResizeObserver";
 import { useStableCallback } from "../hooks/useStableCallback";
@@ -15,7 +16,6 @@ import { getEstimatedSize as getEstimatedSizeUtil } from "./getEstimatedSize";
 import { getOffsetForIndex } from "./getOffsetForIndex";
 import { getStartStopIndices as getStartStopIndicesUtil } from "./getStartStopIndices";
 import type { Direction, SizeFunction } from "./types";
-import { useCachedBounds } from "./useCachedBounds";
 import { useItemSize } from "./useItemSize";
 
 export function useVirtualizer<Props extends object>({

--- a/lib/hooks/useCachedBounds.test.ts
+++ b/lib/hooks/useCachedBounds.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { EMPTY_OBJECT } from "../../src/constants";
-import { useCachedBounds } from "./useCachedBounds";
+import { useCachedBounds } from "../hooks/useCachedBounds";
 
 describe("useCachedBounds", () => {
   test("should cache the CachedBounds unless props change", () => {

--- a/lib/hooks/useCachedBounds.ts
+++ b/lib/hooks/useCachedBounds.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { createCachedBounds } from "./createCachedBounds";
-import type { CachedBounds, SizeFunction } from "./types";
+import { createCachedBounds } from "../core/createCachedBounds";
+import type { CachedBounds, SizeFunction } from "../core/types";
 
 export function useCachedBounds<Props extends object>({
   itemCount,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,7 @@ export {
   type ListProps,
   type RowComponentProps
 } from "./components/list/types";
+export { useCachedBounds } from "./hooks/useCachedBounds";
 export { useDynamicRowHeight } from "./components/list/useDynamicRowHeight";
 export { useListCallbackRef } from "./components/list/useListCallbackRef";
 export { useListRef } from "./components/list/useListRef";


### PR DESCRIPTION
Possible alternative to #866

```tsx
import { List, useCachedBounds } from "react-window";

function Example({ items }) {
  const cachedBounds = useCachedBounds({
    itemCount: items.length,
    itemProps: { items },
    itemSize: 25,
  });

  const rowHeightFunction = useCallback((index:number)=> {
    return cachedBounds.get(index).size;
  },[cachedBounds])

  return <List
    rowCount={items.length}
    rowHeight={rowHeightFunction}
    rowProps={{ items }}
    {...rest}
  />

  // ...
}
```